### PR TITLE
Update CPU-specific memory section in linker script

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -54,9 +54,9 @@ SECTIONS
     PROVIDE(_stack_end = .);
   } >ram AT>ram
 
-  .cpu_specific_memory : {
-    PROVIDE( _cpu_specific_memory = . );
-    . = . + 16; # 4つのCPU用に16バイト確保（必要に応じて調整）
-  } >ram AT>ram
+  #.cpu_specific_memory : {
+  #  PROVIDE( _cpu_specific_memory = . );
+  #  . = . + 16*1; # Reserve 16 bytes per CPU (adjust as needed)
+  #} >ram AT>ram
 }
 


### PR DESCRIPTION
Fix: #3 

- Comment out .cpu_specific_memory section
- Translate Japanese comment to English
- Adjust memory allocation to be more flexible (16*1 instead of 16)

This change allows for easier adjustment of CPU-specific memory allocation
and improves code readability for non-Japanese speakers.