### PR TITLE
Initialize reset section and refactor linker script

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -1,6 +1,6 @@
-OUTPUT_ARCH( "riscv" )
+OUTPUT_ARCH("riscv")
 
-ENTRY( _start )
+ENTRY(_start)
 
 MEMORY
 {

--- a/start.s
+++ b/start.s
@@ -1,1 +1,6 @@
-
+  .section .reset, "ax", @progbits
+  .global _start, @function
+_start:
+1:
+  wfi
+  j 1b


### PR DESCRIPTION
This pull request introduces the initial reset section and refactors the linker script.

Changes:
- Add reset section and _start function in start.s
  - Create .reset section
  - Define global _start function
  - Implement infinite loop with wfi instruction
- Remove whitespace in linker.ld
  - Delete unnecessary spaces in OUTPUT_ARCH and ENTRY directives

These changes set up the basic structure for the system's reset and 
initialization process, and improve code formatting consistency in the 
linker script.