### PR TITLE
Add SPDX License Headers to Project Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Daisuke Nagao
+# SPDX-License-Identifier: MIT
 # CMakeLists.txt for RISC-V Bare-metal Project
 cmake_minimum_required(VERSION 3.22)
 

--- a/linker.ld
+++ b/linker.ld
@@ -1,3 +1,5 @@
+/* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
+/* SPDX-License-Identifier: MIT */
 OUTPUT_ARCH("riscv")
 
 ENTRY(_start)
@@ -54,9 +56,12 @@ SECTIONS
     PROVIDE(_stack_end = .);
   } >ram AT>ram
 
-  #.cpu_specific_memory : {
-  #  PROVIDE( _cpu_specific_memory = . );
-  #  . = . + 16*1; # Reserve 16 bytes per CPU (adjust as needed)
-  #} >ram AT>ram
+  /* Reserve 16 bytes per CPU (adjust as needed) */
+  /*
+  .cpu_specific_memory : {
+    PROVIDE( _cpu_specific_memory = . );
+    . = . + 16*1;
+  } >ram AT>ram
+  */
 }
 

--- a/start.s
+++ b/start.s
@@ -1,3 +1,5 @@
+/* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
+/* SPDX-License-Identifier: MIT */
   .section .reset, "ax", @progbits
   .global _start, @function
 _start:

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Daisuke Nagao
+# SPDX-License-Identifier: MIT
 # RISC-V Bare-metal Toolchain File for Windows using Clang
 
 # Set system name and processor


### PR DESCRIPTION
## Description
This pull request adds SPDX license headers to key project files to ensure compliance with project licensing standards and improve transparency. The following changes have been made:

- Added `SPDX-FileCopyrightText` and `SPDX-License-Identifier` to:
  - `CMakeLists.txt`
  - `linker.ld`
  - `start.s`
  - `toolchain.cmake`
- Updated comments in `linker.ld` to replace non-standard `#` comments with `/* */` for compatibility with linker script conventions.

These changes improve the maintainability of the codebase and align the project with SPDX standards.

## Files Updated
1. **`CMakeLists.txt`**
   - Added SPDX license headers at the top of the file.

2. **`linker.ld`**
   - Added SPDX license headers.
   - Updated comments to use `/* */` syntax for compatibility with GNU linker scripts.

3. **`start.s`**
   - Added SPDX license headers.

4. **`toolchain.cmake`**
   - Added SPDX license headers.

## Checklist
- [x] SPDX headers added to all relevant files.
- [x] Non-standard comments in `linker.ld` updated.
- [x] Verified compatibility with build system and toolchain.

## Testing
- Verified successful build using the existing toolchain (`clang` for RISC-V bare-metal project).