### PR TITLE
Integrate `tkmc_start` Function into the Startup Routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Introduced the `tkmc_start` function in `main.c` as a placeholder for transitioning to the C runtime.
+- Added initialization for the global pointer (`gp`) and stack pointer (`sp`) in the assembly startup routine in `start.s`.
+- Integrated a call to `tkmc_start` in the assembly startup routine to enable the transition from assembly to C code.
+- Included SPDX license headers to ensure compliance with project licensing standards.
 - Added an assembly file `start.s` for initialization, providing basic setup for the RISC-V target.
 - Added `main.c` as the entry point of the project.
 - Added `CMakeLists.txt` to support building for the RISC-V bare-metal environment:
@@ -19,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Clang toolchain file `toolchain.cmake` for the RISC-V bare-metal environment.
 
 ### Changed
-- None.
+- Updated `start.s` to use `.option norelax` and `.option relax` directives for proper handling of the `gp` initialization.
 
 ### Fixed
 - None.

--- a/main.c
+++ b/main.c
@@ -1,1 +1,6 @@
+/* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
+/* SPDX-License-Identifier: MIT */
 
+void tkmc_start(int a0, int a1) {
+    return;
+}

--- a/start.s
+++ b/start.s
@@ -3,6 +3,9 @@
   .section .reset, "ax", @progbits
   .global _start, @function
 _start:
+  .option norelax
+  la gp, __global_pointer$
+  .option relax
 1:
   wfi
   j 1b

--- a/start.s
+++ b/start.s
@@ -7,6 +7,7 @@ _start:
   la gp, __global_pointer$
   .option relax
   la sp, _stack_end
+  call tkmc_start
 1:
   wfi
   j 1b

--- a/start.s
+++ b/start.s
@@ -6,6 +6,7 @@ _start:
   .option norelax
   la gp, __global_pointer$
   .option relax
+  la sp, _stack_end
 1:
   wfi
   j 1b


### PR DESCRIPTION
## Description
This pull request introduces a new function `tkmc_start` in `main.c` and integrates it into the assembly startup routine in `start.s`. This ensures a smooth transition from the assembly startup sequence to the C runtime environment.

### Changes Made
1. **`main.c`**:
   - Added the `tkmc_start` function with a placeholder implementation.
   - Included SPDX license headers for compliance with project licensing standards.

2. **`start.s`**:
   - Initialized the global pointer (`gp`) using `la gp, __global_pointer$` with `.option norelax` and `.option relax`.
   - Initialized the stack pointer (`sp`) using `la sp, _stack_end`.
   - Added a `call tkmc_start` instruction to transition from the assembly routine to the C code.

## Files Updated
- `main.c`
- `start.s`

## Checklist
- [x] Added the `tkmc_start` function in `main.c`.
- [x] Integrated `tkmc_start` into the assembly startup routine.
- [x] Tested the changes for correct assembly to C transition.

## Testing
- Verified that the assembly startup routine initializes `gp` and `sp` correctly.
- Confirmed that the `call tkmc_start` instruction successfully transitions to the C runtime.

