### PR TITLE
Add .gitignore file for common build artifacts and generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,67 @@
 # SPDX-FileCopyrightText: 2024 Daisuke Nagao
 #
 # SPDX-License-Identifier: CC0-1.0
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 Daisuke Nagao
 #
 # SPDX-License-Identifier: CC0-1.0
+.cache/*
+
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Daisuke Nagao
+#
+# SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
This pull request adds a `.gitignore` file to exclude common build artifacts and generated files from version control.

## Changes
- Created a new `.gitignore` file with the following exclusions:
  - Build system files (`CMakeCache.txt`, `CMakeFiles/`, `Makefile`, etc.)
  - Temporary files and cache directories (`.cache/`, `*.tmp`, etc.)
  - Compiled object files and binaries (`*.o`, `*.so`, `*.exe`, etc.)
  - Precompiled headers (`*.gch`, `*.pch`)
  - Debug and kernel module files (`*.pdb`, `*.mod*`, etc.)

## Rationale
- Prevents unnecessary files from being tracked in the repository.
- Simplifies version control by excluding platform-specific and build-related files.
- Improves repository cleanliness for all collaborators.