### PR TITLE
Add `.bss` section initialization process in startup routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a new static function `clear_bss` in `main.c` to clear the `.bss` section during initialization.
+- Integrated a call to the `clear_bss` function within `tkmc_start` to ensure uninitialized variables are properly set to zero.
 - Introduced the `tkmc_start` function in `main.c` as a placeholder for transitioning to the C runtime.
 - Added initialization for the global pointer (`gp`) and stack pointer (`sp`) in the assembly startup routine in `start.s`.
 - Integrated a call to `tkmc_start` in the assembly startup routine to enable the transition from assembly to C code.

--- a/main.c
+++ b/main.c
@@ -8,4 +8,10 @@ void tkmc_start(int a0, int a1) {
   return;
 }
 
-static void clear_bss(void) {}
+static void clear_bss(void) {
+  extern int *_bss_start;
+  extern int *_bss_end;
+  for (int *ptr = _bss_start; ptr < _bss_end; ++ptr) {
+    *ptr = 0;
+  }
+}

--- a/main.c
+++ b/main.c
@@ -1,6 +1,11 @@
 /* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
 /* SPDX-License-Identifier: MIT */
 
+static void clear_bss(void);
+
 void tkmc_start(int a0, int a1) {
-    return;
+  clear_bss();
+  return;
 }
+
+static void clear_bss(void) {}


### PR DESCRIPTION
This pull request introduces a process to clear the `.bss` section during system initialization, ensuring proper setup of uninitialized variables in the runtime environment.

## Changes
- **`main.c`**:
  - Added a new static function `clear_bss` to initialize the `.bss` section by setting all variables to zero.
  - Integrated a call to the `clear_bss` function within the `tkmc_start` function.

- **CHANGELOG.md**:
  - Documented the addition of the `clear_bss` function and its integration into `tkmc_start`.

## Rationale
- Ensures compliance with standard C runtime initialization practices by clearing the `.bss` section.
- Provides a reliable environment for uninitialized variables, preventing undefined behavior during runtime.
