### PR TITLE
Add `.clang-format` file and update CHANGELOG and `CMakeLists.txt`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024 Daisuke Nagao
+#
+# SPDX-License-Identifier: CC0-1.0
+BasedOnStyle: LLVM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Included a `.clang-format` file to standardize code formatting, based on the LLVM style:
+  - Added SPDX license headers to comply with CC0-1.0 license requirements.
 - Added a new static function `clear_bss` in `main.c` to clear the `.bss` section during initialization.
 - Integrated a call to the `clear_bss` function within `tkmc_start` to ensure uninitialized variables are properly set to zero.
 - Introduced the `tkmc_start` function in `main.c` as a placeholder for transitioning to the C runtime.
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Clang toolchain file `toolchain.cmake` for the RISC-V bare-metal environment.
 
 ### Changed
+- Updated `CMakeLists.txt` to include additional spacing for SPDX license header clarity.
 - Updated `start.s` to use `.option norelax` and `.option relax` directives for proper handling of the `gp` initialization.
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Daisuke Nagao
+#
 # SPDX-License-Identifier: MIT
+
 # CMakeLists.txt for RISC-V Bare-metal Project
 cmake_minimum_required(VERSION 3.22)
 


### PR DESCRIPTION
This pull request introduces a `.clang-format` configuration file and updates relevant documentation and files to enhance project maintainability and readability.

## Changes

### Added
- **`.clang-format`**:
  - Introduced a `.clang-format` file based on the LLVM style for consistent code formatting.
  - Added SPDX license headers in compliance with the CC0-1.0 license.

- **CHANGELOG.md**:
  - Documented the addition of the `.clang-format` file.
  - Highlighted updates to `CMakeLists.txt` for improved formatting.

### Changed
- **`CMakeLists.txt`**:
  - Improved formatting by adding spacing to enhance clarity and readability of the SPDX license headers.

## Rationale
- Ensures code formatting is standardized across the project, improving readability and maintainability.
