### PR TITLE
Add Task Launching Mechanism and Sample Task Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,37 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Included `launch_task.s` to implement the `tkmc_launch_task` assembly routine for launching tasks.
 - Added `task1.c` to define a basic task that outputs "Hello, world." to the UART0 interface.
-- Updated `main.c` to:
-  - Declare the `task1` function and its stack.
-  - Call `tkmc_launch_task` to launch `task1` during initialization.
-- Added `launch_task.s` and `task1.c` as sources in `CMakeLists.txt`.
-- Updated `linker.ld`:
-  - Refined the license header formatting.
-- Updated license headers across all source files for consistent style and clarity.
-- Added `README.md` to provide project details, including:
-  - Project description, current status, requirements, and next steps.
+- Updated `main.c` to declare the `task1` function and its stack, and call `tkmc_launch_task` to initialize and launch `task1`.
+- Added `README.md` with project details, including:
+  - Description, current status, and setup requirements.
   - Instructions for running the RTOS on QEMU using a RISC-V processor.
-- Included a `.clang-format` file to standardize code formatting, based on the LLVM style:
-  - Added SPDX license headers to comply with CC0-1.0 license requirements.
-- Added a new static function `clear_bss` in `main.c` to clear the `.bss` section during initialization.
-- Integrated a call to the `clear_bss` function within `tkmc_start` to ensure uninitialized variables are properly set to zero.
-- Introduced the `tkmc_start` function in `main.c` as a placeholder for transitioning to the C runtime.
-- Added initialization for the global pointer (`gp`) and stack pointer (`sp`) in the assembly startup routine in `start.s`.
-- Integrated a call to `tkmc_start` in the assembly startup routine to enable the transition from assembly to C code.
-- Included SPDX license headers to ensure compliance with project licensing standards.
-- Added an assembly file `start.s` for initialization, providing basic setup for the RISC-V target.
-- Added `main.c` as the entry point of the project.
-- Added `CMakeLists.txt` to support building for the RISC-V bare-metal environment:
-  - Configured for Clang compiler usage.
-  - Integrated custom linker script (`linker.ld`).
-  - Added custom build step to generate a binary file using `objcopy`.
-  - Included a custom target to display binary size in Berkeley format.
-- Added `linker.ld` to define memory layout and section settings.
-- Added Clang toolchain file `toolchain.cmake` for the RISC-V bare-metal environment.
+- Included a `.clang-format` file to standardize code formatting, based on the LLVM style.
+- Enhanced runtime initialization in `main.c` with a static function `clear_bss` to clear the `.bss` section.
+- Integrated `start.s` for RISC-V environment initialization, with a call to `tkmc_start` for transitioning from assembly to C runtime.
+- Added `CMakeLists.txt` for RISC-V bare-metal development, including:
+  - Clang compiler setup, linker script integration, and custom build steps.
+  - A custom target to display binary size in Berkeley format.
+- Added `toolchain.cmake` for managing the RISC-V bare-metal toolchain.
+- Included `linker.ld` to define memory layout and section settings.
 
 ### Changed
-- Updated `CMakeLists.txt` to include additional spacing for SPDX license header clarity.
-- Updated `start.s` to use `.option norelax` and `.option relax` directives for proper handling of the `gp` initialization.
+- Updated all source files with consistent SPDX license header formatting.
+- Updated `start.s` to include `.option norelax` and `.option relax` for proper global pointer (`gp`) handling.
 
 ### Fixed
 - None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Included `launch_task.s` to implement the `tkmc_launch_task` assembly routine for launching tasks.
+- Added `task1.c` to define a basic task that outputs "Hello, world." to the UART0 interface.
+- Updated `main.c` to:
+  - Declare the `task1` function and its stack.
+  - Call `tkmc_launch_task` to launch `task1` during initialization.
+- Added `launch_task.s` and `task1.c` as sources in `CMakeLists.txt`.
+- Updated `linker.ld`:
+  - Refined the license header formatting.
+- Updated license headers across all source files for consistent style and clarity.
 - Added `README.md` to provide project details, including:
   - Project description, current status, requirements, and next steps.
   - Instructions for running the RTOS on QEMU using a RISC-V processor.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(COMMON_FLAGS -ffreestanding -nostdlib)
 # Specify the executable
 add_executable(${EXECUTABLE})
 
-target_sources(${EXECUTABLE} PRIVATE start.s main.c)
+target_sources(${EXECUTABLE} PRIVATE start.s main.c task1.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,12 @@ set(COMMON_FLAGS -ffreestanding -nostdlib)
 # Specify the executable
 add_executable(${EXECUTABLE})
 
-target_sources(${EXECUTABLE} PRIVATE start.s main.c task1.c)
+target_sources(${EXECUTABLE} PRIVATE start.s main.c launch_task.s task1.c)
 
 # Set CMake compilation flags
 target_compile_options(
   ${EXECUTABLE} PRIVATE $<$<COMPILE_LANGUAGE:C>:${COMMON_FLAGS}>
-                        $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>)
+  $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>)
 
 # Set required standards
 target_compile_features(${EXECUTABLE} PRIVATE c_std_11 cxx_std_20)

--- a/launch_task.s
+++ b/launch_task.s
@@ -7,4 +7,6 @@
 .section .text
   .global tkmc_launch_task, @function
 tkmc_launch_task:
+  mv sp, a0
+  mv ra, a1
   ret

--- a/launch_task.s
+++ b/launch_task.s
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+.section .text
+  .global tkmc_launch_task, @function
+tkmc_launch_task:
+  ret

--- a/linker.ld
+++ b/linker.ld
@@ -1,5 +1,8 @@
-/* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
-/* SPDX-License-Identifier: MIT */
+/*
+ * SPDX-FileCopyrightText: 2024 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
 OUTPUT_ARCH("riscv")
 
 ENTRY(_start)

--- a/main.c
+++ b/main.c
@@ -10,6 +10,7 @@ extern void task1(void);
 
 void tkmc_start(int a0, int a1) {
   clear_bss();
+  task1();
   return;
 }
 

--- a/main.c
+++ b/main.c
@@ -1,5 +1,8 @@
-/* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
-/* SPDX-License-Identifier: MIT */
+/*
+ * SPDX-FileCopyrightText: 2024 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 static void clear_bss(void);
 

--- a/main.c
+++ b/main.c
@@ -8,9 +8,13 @@ static void clear_bss(void);
 
 extern void task1(void);
 
+static unsigned int task1_stack[1024];
+extern void tkmc_launch_task(unsigned int *sp_end, void (*f)(void));
+
 void tkmc_start(int a0, int a1) {
   clear_bss();
-  task1();
+  tkmc_launch_task(task1_stack + sizeof(task1_stack) / sizeof(task1_stack[0]),
+                   task1);
   return;
 }
 

--- a/main.c
+++ b/main.c
@@ -3,6 +3,8 @@
 
 static void clear_bss(void);
 
+extern void task1(void);
+
 void tkmc_start(int a0, int a1) {
   clear_bss();
   return;

--- a/start.s
+++ b/start.s
@@ -1,5 +1,8 @@
-/* SPDX-FileCopyrightText: 2024 Daisuke Nagao */
-/* SPDX-License-Identifier: MIT */
+/*
+ * SPDX-FileCopyrightText: 2024 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
   .section .reset, "ax", @progbits
   .global _start, @function
 _start:

--- a/task1.c
+++ b/task1.c
@@ -4,7 +4,23 @@
  * SPDX-License-Identifier: MIT
  */
 
+volatile unsigned int *const UART0_BASE = (unsigned int *)0x10000000;
+
 void task1(void) {
+  *UART0_BASE = 'H';
+  *UART0_BASE = 'e';
+  *UART0_BASE = 'l';
+  *UART0_BASE = 'l';
+  *UART0_BASE = 'o';
+  *UART0_BASE = ',';
+  *UART0_BASE = ' ';
+  *UART0_BASE = 'w';
+  *UART0_BASE = 'o';
+  *UART0_BASE = 'r';
+  *UART0_BASE = 'l';
+  *UART0_BASE = 'd';
+  *UART0_BASE = '.';
+  *UART0_BASE = '\n';
   while (1) {
   }
 }

--- a/task1.c
+++ b/task1.c
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+void task1(void) {
+  while (1) {
+  }
+}

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Daisuke Nagao
+#
 # SPDX-License-Identifier: MIT
+
 # RISC-V Bare-metal Toolchain File for Windows using Clang
 
 # Set system name and processor


### PR DESCRIPTION
This pull request introduces a task launching mechanism and a sample task implementation to demonstrate basic multitasking functionality in the RTOS.

## Changes

### Added
- **`launch_task.s`**:
  - Implemented `tkmc_launch_task` to initialize the stack pointer (`sp`) and return address (`ra`) for task execution.

- **`task1.c`**:
  - Added a sample task (`task1`) that outputs "Hello, world." to a UART device.

### Updated
- **`CMakeLists.txt`**:
  - Included `launch_task.s` and `task1.c` in the project source files.

- **`main.c`**:
  - Declared and allocated a stack for `task1`.
  - Integrated `tkmc_launch_task` to launch `task1` using the prepared stack.

- **`linker.ld`, `start.s`, and `toolchain.cmake`**:
  - Adjusted formatting and added SPDX license headers for consistency.

### Rationale
- Introduces the ability to define and launch tasks in the RTOS, a critical step toward supporting multitasking.
- Demonstrates task execution with a simple `task1` implementation that outputs text to UART.
- Ensures compliance with licensing requirements through the addition of SPDX headers.

## Future Work
- Expand task management to include scheduling and inter-task communication.
- Generalize task launching for multiple tasks and dynamic task creation.
