### PR TITLE
Add Multitasking Support with Context Switching and Demo Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,28 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Included `launch_task.s` to implement the `tkmc_launch_task` assembly routine for launching tasks.
-- Added `task1.c` to define a basic task that outputs "Hello, world." to the UART0 interface.
-- Enhanced `CMakeLists.txt` with:
-  - Support for `typedef.h` generation using `typedef.h.in` and `DetermineTypes.cmake`.
-  - New options: `TK_HAS_DOUBLEWORD` (for 64-bit types) and `TK_SUPPORT_USEC` (for microsecond-related types).
-  - Updated include directories to include `${CMAKE_BINARY_DIR}/include/`.
-  - Added conditional compile definitions based on options (`TK_HAS_DOUBLEWORD` and `TK_SUPPORT_USEC`).
-- Added `DetermineTypes.cmake` to dynamically determine data type sizes and generate type definitions.
-- Included `typedef.h.in` to define configurable data types and constants for the project.
-- Updated `main.c`:
-  - Included `typedef.h`.
-  - Declared the `task1` function and its stack.
-  - Integrated a call to `tkmc_launch_task` to initialize and launch `task1`.
-- Added `toolchain.cmake` for managing the RISC-V bare-metal toolchain.
-- Included `linker.ld` to define memory layout and section settings.
+- Included `context_switch.s` to implement context switching with the `__context_switch` and `__launch_task` routines.
+- Added support for task management in `main.c`:
+  - Implemented `tkmc_create_task` for creating tasks with their stacks and entry points.
+  - Added `tkmc_start_task` to mark tasks as ready.
+  - Implemented `tkmc_context_switch` for cooperative multitasking between tasks.
+  - Updated task initialization to create and launch `task1` and `task2`.
+- Introduced `task1.c` and `task2.c` for demonstration tasks:
+  - `task1` outputs "Hello, world." via UART using `putstring`.
+  - `task2` outputs "FizzBuzz" via UART using `putstring`.
+- Added `putstring.h` to provide a helper function for UART-based string output.
+- Enhanced `typedef.h.in` with additional application-specific types:
+  - Attributes (`ATR`), error codes (`ER`), function codes (`FN`), and priorities (`PRI`).
+- Updated `CMakeLists.txt`:
+  - Integrated `context_switch.s`, `task1.c`, `task2.c`, and `putstring.h`.
+  - Enabled the generation of `typedef.h` from `typedef.h.in` using `DetermineTypes.cmake`.
+  - Added new configuration options: `TK_HAS_DOUBLEWORD` for 64-bit support and `TK_SUPPORT_USEC` for microsecond-related types.
 
 ### Changed
-- Updated all source files with consistent SPDX license header formatting.
-- Updated `start.s` to include `.option norelax` and `.option relax` for proper global pointer (`gp`) handling.
+- Refactored `start.s`:
+  - Improved alignment with `.balign 4`.
+  - Updated handling of the global pointer (`gp`) with `.option norelax` and `.option relax`.
+- Replaced the deprecated `tkmc_launch_task` in `launch_task.s` with `__launch_task` from `context_switch.s`.
+- Applied consistent SPDX license header formatting across all source files.
 
 ### Fixed
 - None.
 
 ### Removed
-- None.
+- Deprecated `tkmc_launch_task` from `launch_task.s` as its functionality is now covered by `__launch_task` in `context_switch.s`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(COMMON_FLAGS -ffreestanding -nostdlib)
 # Specify the executable
 add_executable(${EXECUTABLE})
 
-target_sources(${EXECUTABLE} PRIVATE start.s main.c launch_task.s task1.c task2.c)
+target_sources(${EXECUTABLE} PRIVATE start.s main.c launch_task.s context_switch.s task1.c task2.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(COMMON_FLAGS -ffreestanding -nostdlib)
 # Specify the executable
 add_executable(${EXECUTABLE})
 
-target_sources(${EXECUTABLE} PRIVATE start.s main.c launch_task.s task1.c)
+target_sources(${EXECUTABLE} PRIVATE start.s main.c launch_task.s task1.c task2.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,16 +58,16 @@ include(DetermineTypes.cmake)
 
 # Generate typedef.h
 configure_file(
-    typedef.h.in
-    ${CMAKE_BINARY_DIR}/include/typedef.h
-    @ONLY
+  typedef.h.in
+  ${CMAKE_BINARY_DIR}/include/typedef.h
+  @ONLY
 )
 
 # Add compile definitions based on options
 if(TK_HAS_DOUBLEWORD)
-    target_compile_definitions(${EXECUTABLE} PUBLIC TK_HAS_DOUBLEWORD)
+  target_compile_definitions(${EXECUTABLE} PUBLIC TK_HAS_DOUBLEWORD)
 endif()
 
 if(TK_SUPPORT_USEC)
-    target_compile_definitions(${EXECUTABLE} PUBLIC TK_SUPPORT_USEC)
+  target_compile_definitions(${EXECUTABLE} PUBLIC TK_SUPPORT_USEC)
 endif()

--- a/context_switch.s
+++ b/context_switch.s
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+  .section .reset, "ax", @progbits
+  .global __context_switch, @function
+  .global __launch_task, @function
+  .balign 4
+__context_switch:
+    /* a0 = next_sp: void** */
+    /* a1 = current_sp: void** */
+    addi  sp, sp, -4*13
+    sw    s0, 0*4(sp)
+    sw    s1, 1*4(sp)
+    sw    s2, 2*4(sp)
+    sw    s3, 3*4(sp)
+    sw    s4, 4*4(sp)
+    sw    s5, 5*4(sp)
+    sw    s6, 6*4(sp)
+    sw    s7, 7*4(sp)
+    sw    s8, 8*4(sp)
+    sw    s9, 9*4(sp)
+    sw    s10, 10*4(sp)
+    sw    s11, 11*4(sp)
+    sw    ra, 12*4(sp)
+    sw    sp, (a1)
+__launch_task:
+    lw    sp, (a0)
+    lw    s0, 0*4(sp)
+    lw    s1, 1*4(sp)
+    lw    s2, 2*4(sp)
+    lw    s3, 3*4(sp)
+    lw    s4, 4*4(sp)
+    lw    s5, 5*4(sp)
+    lw    s6, 6*4(sp)
+    lw    s7, 7*4(sp)
+    lw    s8, 8*4(sp)
+    lw    s9, 9*4(sp)
+    lw    s10, 10*4(sp)
+    lw    s11, 11*4(sp)
+    lw    ra, 12*4(sp)
+    addi  sp, sp, 4*13
+    ret

--- a/launch_task.s
+++ b/launch_task.s
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-.section .text
+  .section .text
   .global tkmc_launch_task, @function
 tkmc_launch_task:
   mv sp, a0

--- a/launch_task.s
+++ b/launch_task.s
@@ -3,10 +3,3 @@
  *
  * SPDX-License-Identifier: MIT
  */
-
-  .section .text
-  .global tkmc_launch_task, @function
-tkmc_launch_task:
-  mv sp, a0
-  mv ra, a1
-  ret

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@ extern void tkmc_launch_task(unsigned int *sp_end, void (*f)(void));
 /* Task Control Block */
 typedef struct TCB {
   void *sp;
+  FP task;
 } TCB;
 
 static TCB tcbs[1] = {
@@ -37,10 +38,13 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   if (new_id < sizeof(tcbs) / sizeof(tcbs[0])) {
     TCB *new_tcb = tcbs + new_id;
     new_tcb->sp = stack_end;
+    new_tcb->task = fp;
   }
 
   return new_id;
 }
+
+static ER tkmc_start_task(ID id) { return 0; }
 
 void tkmc_start(int a0, int a1) {
   clear_bss();

--- a/main.c
+++ b/main.c
@@ -22,6 +22,26 @@ static TCB tcbs[1] = {
     {NULL},
 };
 
+static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
+  B *stack_begin = (B *)sp;
+  B *stack_end = stack_begin + stksz;
+
+  ID new_id = sizeof(tcbs) / sizeof(tcbs[0]);
+  for (unsigned int i = 0; i < sizeof(tcbs) / sizeof(tcbs[0]); ++i) {
+    if (tcbs[i].sp != NULL) {
+      new_id = i;
+      break;
+    }
+  }
+
+  if (new_id < sizeof(tcbs) / sizeof(tcbs[0])) {
+    TCB *new_tcb = tcbs + new_id;
+    new_tcb->sp = stack_end;
+  }
+
+  return new_id;
+}
+
 void tkmc_start(int a0, int a1) {
   clear_bss();
   tkmc_launch_task(task1_stack + sizeof(task1_stack) / sizeof(task1_stack[0]),

--- a/main.c
+++ b/main.c
@@ -27,8 +27,8 @@ static TCB tcbs[2] = {
 };
 
 static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
-  B *stack_begin = (B *)sp;
-  B *stack_end = stack_begin + stksz;
+  UW *stack_begin = (UW *)sp;
+  UW *stack_end = stack_begin + (stksz >> 2);
 
   ID new_id = sizeof(tcbs) / sizeof(tcbs[0]);
   for (unsigned int i = 0; i < sizeof(tcbs) / sizeof(tcbs[0]); ++i) {

--- a/main.c
+++ b/main.c
@@ -13,6 +13,15 @@ extern void task1(void);
 static unsigned int task1_stack[1024];
 extern void tkmc_launch_task(unsigned int *sp_end, void (*f)(void));
 
+/* Task Control Block */
+typedef struct TCB {
+  void *sp;
+} TCB;
+
+static TCB tcbs[1] = {
+    {NULL},
+};
+
 void tkmc_start(int a0, int a1) {
   clear_bss();
   tkmc_launch_task(task1_stack + sizeof(task1_stack) / sizeof(task1_stack[0]),

--- a/main.c
+++ b/main.c
@@ -9,8 +9,10 @@
 static void clear_bss(void);
 
 extern void task1(void);
+extern void task2(void);
 
 static unsigned int task1_stack[1024];
+static unsigned int task2_stack[1024];
 extern void tkmc_launch_task(unsigned int *sp_end, void (*f)(void));
 
 /* Task Control Block */
@@ -19,7 +21,8 @@ typedef struct TCB {
   FP task;
 } TCB;
 
-static TCB tcbs[1] = {
+static TCB tcbs[2] = {
+    {NULL, NULL},
     {NULL, NULL},
 };
 
@@ -53,6 +56,7 @@ static ER tkmc_start_task(ID id) {
 void tkmc_start(int a0, int a1) {
   clear_bss();
   ID task1_id = tkmc_create_task(task1_stack, sizeof(task1_stack), (FP)task1);
+  ID task2_id = tkmc_create_task(task2_stack, sizeof(task2_stack), (FP)task2);
   tkmc_start_task(task1_id);
   return;
 }

--- a/main.c
+++ b/main.c
@@ -20,7 +20,7 @@ typedef struct TCB {
 } TCB;
 
 static TCB tcbs[1] = {
-    {NULL},
+    {NULL, NULL},
 };
 
 static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
@@ -29,7 +29,7 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
 
   ID new_id = sizeof(tcbs) / sizeof(tcbs[0]);
   for (unsigned int i = 0; i < sizeof(tcbs) / sizeof(tcbs[0]); ++i) {
-    if (tcbs[i].sp != NULL) {
+    if (tcbs[i].sp == NULL) {
       new_id = i;
       break;
     }
@@ -44,12 +44,16 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   return new_id;
 }
 
-static ER tkmc_start_task(ID id) { return 0; }
+static ER tkmc_start_task(ID id) {
+  TCB *tcb = tcbs + id;
+  tkmc_launch_task(tcb->sp, tcb->task);
+  return 0;
+}
 
 void tkmc_start(int a0, int a1) {
   clear_bss();
-  tkmc_launch_task(task1_stack + sizeof(task1_stack) / sizeof(task1_stack[0]),
-                   task1);
+  ID task1_id = tkmc_create_task(task1_stack, sizeof(task1_stack), (FP)task1);
+  tkmc_start_task(task1_id);
   return;
 }
 

--- a/main.c
+++ b/main.c
@@ -11,8 +11,8 @@ static void clear_bss(void);
 extern void task1(void);
 extern void task2(void);
 
-static unsigned int task1_stack[1024];
-static unsigned int task2_stack[1024];
+static UW task1_stack[1024];
+static UW task2_stack[1024];
 extern void tkmc_launch_task(unsigned int *sp_end, void (*f)(void));
 
 /* Task Control Block */

--- a/putstring.h
+++ b/putstring.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef UUID_0194511A_FCFC_7A1D_B75D_151971DE4900
+#define UUID_0194511A_FCFC_7A1D_B75D_151971DE4900
+
+volatile static unsigned int *const UART0_BASE = (unsigned int *)0x10000000;
+
+static void putstring(const char *str) {
+  while (*str != '\0') {
+    *UART0_BASE = *str;
+    ++str;
+  }
+}
+
+#endif /* UUID_0194511A_FCFC_7A1D_B75D_151971DE4900 */

--- a/start.s
+++ b/start.s
@@ -5,6 +5,7 @@
  */
   .section .reset, "ax", @progbits
   .global _start, @function
+  .balign 4
 _start:
   .option norelax
   la gp, __global_pointer$

--- a/task1.c
+++ b/task1.c
@@ -6,21 +6,15 @@
 
 volatile unsigned int *const UART0_BASE = (unsigned int *)0x10000000;
 
+static void putstring(const char *str) {
+  while (*str != '\0') {
+    *UART0_BASE = *str;
+    ++str;
+  }
+}
+
 void task1(void) {
-  *UART0_BASE = 'H';
-  *UART0_BASE = 'e';
-  *UART0_BASE = 'l';
-  *UART0_BASE = 'l';
-  *UART0_BASE = 'o';
-  *UART0_BASE = ',';
-  *UART0_BASE = ' ';
-  *UART0_BASE = 'w';
-  *UART0_BASE = 'o';
-  *UART0_BASE = 'r';
-  *UART0_BASE = 'l';
-  *UART0_BASE = 'd';
-  *UART0_BASE = '.';
-  *UART0_BASE = '\n';
+  putstring("Hello, world.\n");
   while (1) {
   }
 }

--- a/task1.c
+++ b/task1.c
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-volatile unsigned int *const UART0_BASE = (unsigned int *)0x10000000;
-
-static void putstring(const char *str) {
-  while (*str != '\0') {
-    *UART0_BASE = *str;
-    ++str;
-  }
-}
+#include "putstring.h"
 
 void task1(void) {
   putstring("Hello, world.\n");

--- a/task1.c
+++ b/task1.c
@@ -5,9 +5,14 @@
  */
 
 #include "putstring.h"
+#include <typedef.h>
+
+extern void tkmc_context_switch(ID tskid);
 
 void task1(void) {
-  putstring("Hello, world.\n");
+  putstring("Hello, world\n");
   while (1) {
+    putstring("Hello, world.\n");
+    tkmc_context_switch(1);
   }
 }

--- a/task2.c
+++ b/task2.c
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "putstring.h"
+
+void task2(void) {
+  putstring("FizzBuzz\n");
+  while (1) {
+  }
+}

--- a/task2.c
+++ b/task2.c
@@ -5,9 +5,14 @@
  */
 
 #include "putstring.h"
+#include <typedef.h>
+
+extern void tkmc_context_switch(ID tskid);
 
 void task2(void) {
   putstring("FizzBuzz\n");
   while (1) {
+    putstring("FizzBuzz.\n");
+    tkmc_context_switch(0);
   }
 }

--- a/typedef.h.in
+++ b/typedef.h.in
@@ -70,6 +70,12 @@ typedef UINT BOOL;
 #define TRUE  1  /* True */
 #define FALSE 0  /* False */
 
+/* Application-specific types for system attributes and functionality */
+typedef INT FN;   /* Function code */
+typedef UW ATR;   /* Object/handler attributes */
+typedef INT ER;   /* Error code */
+typedef INT PRI;  /* Priority */
+
 /* Time-related types */
 typedef W                    TMO;  /* Timeout in milliseconds */
 #ifdef TK_SUPPORT_USEC


### PR DESCRIPTION


This pull request introduces a multitasking framework with cooperative context switching and two demo tasks (`task1` and `task2`) to demonstrate the RTOS's capabilities.

## Changes

### Added
- **Multitasking Framework**:
  - **`context_switch.s`**: Implements `__context_switch` and `__launch_task` routines for task context switching and launching.
  - **Task Management in `main.c`**:
    - `tkmc_create_task`: Creates tasks with assigned stacks and entry points.
    - `tkmc_start_task`: Marks tasks as ready to run.
    - `tkmc_context_switch`: Switches execution between tasks cooperatively.
  - Task control blocks (TCBs) for managing task states and stacks.

- **Demo Tasks**:
  - **`task1.c`**: Outputs "Hello, world." repeatedly via UART and switches to `task2`.
  - **`task2.c`**: Outputs "FizzBuzz" repeatedly via UART and switches back to `task1`.

- **Utilities**:
  - **`putstring.h`**: Provides a helper function for UART-based string output.

- **Enhanced Type Definitions**:
  - Added application-specific types (`ATR`, `ER`, `FN`, `PRI`) in `typedef.h.in`.

### Updated
- **`CMakeLists.txt`**:
  - Integrated `context_switch.s`, `task1.c`, `task2.c`, and `putstring.h` into the build process.

- **`start.s`**:
  - Improved alignment with `.balign 4` for better performance.
  - Updated to use `.option norelax` for proper global pointer (`gp`) handling.

- **`task1.c`**:
  - Refactored to use `putstring` for UART output.
  - Integrated `tkmc_context_switch` for switching to `task2`.

### Removed
- Deprecated `tkmc_launch_task` from `launch_task.s` in favor of `__launch_task` in `context_switch.s`.

### Rationale
- Establishes foundational multitasking capabilities in the RTOS.
- Demonstrates cooperative context switching with simple demo tasks.
- Enhances modularity and code reuse through helper utilities like `putstring`.
- Improves licensing compliance and consistency across all files with SPDX headers.
