### PR TITLE
Add CMake Presets for Build Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `CMakePresets.json` to define build and configure presets:
+  - Presets include `debug`, `release`, `relwithdebinfo`, and `minsizerel` for different build configurations.
+  - Common settings are inherited from the `base` preset, using the Ninja generator and exporting compile commands.
+  - Supports `CMAKE_TOOLCHAIN_FILE` for RISC-V bare-metal toolchain configuration.
 - Included `context_switch.s` to implement context switching with the `__context_switch` and `__launch_task` routines.
-- Added support for task management in `main.c`:
+- Enhanced task management in `main.c`:
   - Implemented `tkmc_create_task` for creating tasks with their stacks and entry points.
   - Added `tkmc_start_task` to mark tasks as ready.
   - Implemented `tkmc_context_switch` for cooperative multitasking between tasks.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,65 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/../build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/toolchain.cmake",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "displayName": "Debug Build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "displayName": "Release Build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "relwithdebinfo",
+      "inherits": "base",
+      "displayName": "Release with Debug Info",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "minsizerel",
+      "inherits": "base",
+      "displayName": "Minimum Size Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "relwithdebinfo",
+      "configurePreset": "relwithdebinfo"
+    },
+    {
+      "name": "minsizerel",
+      "configurePreset": "minsizerel"
+    }
+  ]
+}


### PR DESCRIPTION

This pull request introduces a `CMakePresets.json` file to streamline the build configuration process with predefined presets, enhancing project usability and maintainability.

## Changes

### Added
- **`CMakePresets.json`**:
  - Defines multiple build and configuration presets:
    - **Presets**:
      - `debug`: For debugging with full symbols.
      - `release`: For optimized builds.
      - `relwithdebinfo`: Optimized builds with debug information.
      - `minsizerel`: Optimized builds with minimal size.
    - **Common Settings**:
      - Inherits from a `base` preset.
      - Uses the Ninja generator for fast builds.
      - Exports compile commands for tooling compatibility.
      - Configures the RISC-V bare-metal toolchain using `CMAKE_TOOLCHAIN_FILE`.

### Updated
- **CHANGELOG.md**:
  - Documented the addition of `CMakePresets.json` and its purpose.

## Rationale
- Simplifies build configuration by standardizing presets for different scenarios.
- Improves build process consistency across development environments.
- Reduces manual configuration, enhancing developer productivity and minimizing errors.
