### PR TITLE
Move Generated `typedef.h` to `include/tk` Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ include(DetermineTypes.cmake)
 # Generate typedef.h
 configure_file(
   typedef.h.in
-  ${CMAKE_BINARY_DIR}/include/typedef.h
+  ${CMAKE_BINARY_DIR}/include/tk/typedef.h
   @ONLY
 )
 

--- a/main.c
+++ b/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <typedef.h>
+#include <tk/typedef.h>
 
 static void clear_bss(void);
 

--- a/task1.c
+++ b/task1.c
@@ -5,7 +5,7 @@
  */
 
 #include "putstring.h"
-#include <typedef.h>
+#include <tk/typedef.h>
 
 extern void tkmc_context_switch(ID tskid);
 

--- a/task2.c
+++ b/task2.c
@@ -5,7 +5,7 @@
  */
 
 #include "putstring.h"
-#include <typedef.h>
+#include <tk/typedef.h>
 
 extern void tkmc_context_switch(ID tskid);
 


### PR DESCRIPTION

This pull request updates the project to move the generated `typedef.h` file to a more specific directory structure (`include/tk`) for improved organization and clarity.

## Changes

### Updated
- **CMake Configuration**:
  - Modified the `configure_file` command in `CMakeLists.txt` to generate `typedef.h` in the `include/tk` directory (`${CMAKE_BINARY_DIR}/include/tk/typedef.h`).

- **Source Files**:
  - Updated include paths for `typedef.h` in the following files:
    - `main.c`
    - `task1.c`
    - `task2.c`
  - Changed `#include <typedef.h>` to `#include <tk/typedef.h>`.

## Rationale
- Improves project organization by grouping related headers under a specific directory (`include/tk`).
- Enhances maintainability by aligning the include directory structure with the project's modular design.
- Reduces potential naming conflicts by scoping the header file under `tk`.
