### PR TITLE
Refactor Task Management into Dedicated Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(${EXECUTABLE})
 target_sources(
   ${EXECUTABLE}
   PRIVATE kernel/asm/rv32/start.s kernel/asm/rv32/launch_task.s
-          kernel/asm/rv32/context_switch.s kernel/start.c task1.c task2.c)
+          kernel/asm/rv32/context_switch.s kernel/start.c kernel/task.c task1.c task2.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -19,12 +19,6 @@ static UW task2_stack[1024];
 extern void __launch_task(void **sp_end);
 extern void __context_switch(void **next_sp, void **current_sp);
 
-extern TCB tkmc_tcbs[2];
-TCB tkmc_tcbs[2] = {
-    {0, NON_EXISTENT, NULL, NULL},
-    {0, NON_EXISTENT, NULL, NULL},
-};
-
 static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   UW *stack_begin = (UW *)sp;
   UW *stack_end = stack_begin + (stksz >> 2);

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -55,8 +55,6 @@ static ER tkmc_start_task(ID tskid) {
   return E_OK;
 }
 
-static TCB *current = NULL;
-
 void tkmc_start(int a0, int a1) {
   clear_bss();
 

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -19,7 +19,8 @@ static UW task2_stack[1024];
 extern void __launch_task(void **sp_end);
 extern void __context_switch(void **next_sp, void **current_sp);
 
-static TCB tkmc_tcbs[2] = {
+extern TCB tkmc_tcbs[2];
+TCB tkmc_tcbs[2] = {
     {0, NON_EXISTENT, NULL, NULL},
     {0, NON_EXISTENT, NULL, NULL},
 };

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -6,6 +6,8 @@
 
 #include <tk/tkernel.h>
 
+#include "task.h"
+
 static void clear_bss(void);
 
 extern void task1(void);
@@ -16,21 +18,6 @@ static UW task2_stack[1024];
 
 extern void __launch_task(void **sp_end);
 extern void __context_switch(void **next_sp, void **current_sp);
-
-enum TaskState {
-  NON_EXISTENT = 0,
-  DORMANT,
-  READY,
-  RUNNING,
-};
-
-/* Task Control Block */
-typedef struct TCB {
-  ID tskid;
-  enum TaskState state;
-  void *sp;
-  FP task;
-} TCB;
 
 static TCB tcbs[2] = {
     {0, NON_EXISTENT, NULL, NULL},

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -64,6 +64,9 @@ static TCB *current = NULL;
 
 void tkmc_start(int a0, int a1) {
   clear_bss();
+
+  tkmc_init_tcb();
+
   ID task1_id = tkmc_create_task(task1_stack, sizeof(task1_stack), (FP)task1);
   ID task2_id = tkmc_create_task(task2_stack, sizeof(task2_stack), (FP)task2);
 

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -19,7 +19,7 @@ static UW task2_stack[1024];
 extern void __launch_task(void **sp_end);
 extern void __context_switch(void **next_sp, void **current_sp);
 
-static TCB tcbs[2] = {
+static TCB tkmc_tcbs[2] = {
     {0, NON_EXISTENT, NULL, NULL},
     {0, NON_EXISTENT, NULL, NULL},
 };
@@ -28,16 +28,16 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   UW *stack_begin = (UW *)sp;
   UW *stack_end = stack_begin + (stksz >> 2);
 
-  ID new_id = sizeof(tcbs) / sizeof(tcbs[0]);
-  for (unsigned int i = 0; i < sizeof(tcbs) / sizeof(tcbs[0]); ++i) {
-    if (tcbs[i].sp == NULL) {
+  ID new_id = sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]);
+  for (unsigned int i = 0; i < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]); ++i) {
+    if (tkmc_tcbs[i].sp == NULL) {
       new_id = i;
       break;
     }
   }
 
-  if (new_id < sizeof(tcbs) / sizeof(tcbs[0])) {
-    TCB *new_tcb = tcbs + new_id;
+  if (new_id < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0])) {
+    TCB *new_tcb = tkmc_tcbs + new_id;
     new_tcb->tskid = new_id;
     new_tcb->state = DORMANT;
     stack_end += -13;
@@ -55,7 +55,7 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
 }
 
 static ER tkmc_start_task(ID tskid) {
-  TCB *tcb = tcbs + tskid;
+  TCB *tcb = tkmc_tcbs + tskid;
   tcb->state = READY;
   return E_OK;
 }
@@ -73,7 +73,7 @@ void tkmc_start(int a0, int a1) {
   tkmc_start_task(task1_id);
   tkmc_start_task(task2_id);
 
-  TCB *tcb1 = tcbs + task1_id;
+  TCB *tcb1 = tkmc_tcbs + task1_id;
   tcb1->state = RUNNING;
   current = tcb1;
 
@@ -85,7 +85,7 @@ void tkmc_start(int a0, int a1) {
 void tkmc_context_switch(ID tskid) {
   TCB *prev = current;
   prev->state = READY;
-  TCB *next = tcbs + tskid;
+  TCB *next = tkmc_tcbs + tskid;
   next->state = RUNNING;
   current = next;
   __context_switch(&next->sp, &prev->sp);

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -6,9 +6,16 @@
 
 #include "task.h"
 
-TCB tkmc_tcbs[2] = {
-    {0, NON_EXISTENT, NULL, NULL},
-    {0, NON_EXISTENT, NULL, NULL},
-};
+TCB tkmc_tcbs[2];
 
-void tkmc_init_tcb(void) {}
+void tkmc_init_tcb(void) {
+  for (int i = 0; i < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]); ++i) {
+    TCB *tcb = &tkmc_tcbs[i];
+    *tcb = (TCB){
+        .tskid = i + 1,
+        .state = NON_EXISTENT,
+        .sp = NULL,
+        .task = NULL,
+    };
+  }
+}

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -6,4 +6,9 @@
 
 #include "task.h"
 
+TCB tkmc_tcbs[2] = {
+    {0, NON_EXISTENT, NULL, NULL},
+    {0, NON_EXISTENT, NULL, NULL},
+};
+
 void tkmc_init_tcb(void) {}

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -5,3 +5,5 @@
  */
 
 #include "task.h"
+
+void tkmc_init_tcb(void) {}

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -7,6 +7,7 @@
 #include "task.h"
 
 TCB tkmc_tcbs[2];
+TCB *current = NULL;
 
 void tkmc_init_tcb(void) {
   for (int i = 0; i < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]); ++i) {

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "task.h"

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -7,4 +7,14 @@
 #ifndef UUID_01948452_C50C_7B25_A131_C2733EF5E067
 #define UUID_01948452_C50C_7B25_A131_C2733EF5E067
 
+#include <tk/tkernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
 #endif /* UUID_01948452_C50C_7B25_A131_C2733EF5E067 */

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -29,6 +29,7 @@ typedef struct TCB {
 } TCB;
 
 extern TCB tkmc_tcbs[2];
+extern TCB *current;
 
 extern void tkmc_init_tcb(void);
 

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -28,6 +28,8 @@ typedef struct TCB {
   FP task;
 } TCB;
 
+extern void tkmc_init_tcb(void);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UUID_01948452_C50C_7B25_A131_C2733EF5E067
+#define UUID_01948452_C50C_7B25_A131_C2733EF5E067
+
+#endif /* UUID_01948452_C50C_7B25_A131_C2733EF5E067 */

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -28,6 +28,8 @@ typedef struct TCB {
   FP task;
 } TCB;
 
+extern TCB tkmc_tcbs[2];
+
 extern void tkmc_init_tcb(void);
 
 #ifdef __cplusplus

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -13,6 +13,21 @@
 extern "C" {
 #endif /* __cplusplus */
 
+enum TaskState {
+  NON_EXISTENT = 0,
+  DORMANT,
+  READY,
+  RUNNING,
+};
+
+/* Task Control Block */
+typedef struct TCB {
+  ID tskid;
+  enum TaskState state;
+  void *sp;
+  FP task;
+} TCB;
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */


### PR DESCRIPTION
# Refactor Task Management into Dedicated Module

This pull request refactors the task management functionality into a dedicated module, improving code organization and maintainability.

## Changes

### Added
- **New Task Management Module**:
  - **`kernel/task.c`**:
    - Contains task-related operations, including:
      - `tkmc_init_tcb`: Initializes the Task Control Blocks (TCBs).
    - Defines `tkmc_tcbs` (an array of TCBs) and `current` (the current task pointer).
  - **`kernel/task.h`**:
    - Declares the `TCB` structure and related enumerations (`TaskState`).
    - Provides external declarations for `tkmc_tcbs`, `current`, and task-related functions.

### Updated
- **`kernel/start.c`**:
  - Moved task management logic to the new task module.
  - Replaced local TCB definitions with references to `tkmc_tcbs` and `current`.
  - Added `#include "task.h"` to use the task management API.
  - Integrated `tkmc_init_tcb` for initializing TCBs during system startup.

- **CMake Configuration**:
  - Added `kernel/task.c` to `target_sources` in `CMakeLists.txt`.

### Rationale
- Improves modularity by separating task management from the startup logic.
- Simplifies future development by isolating task-specific functionality in a dedicated module.
- Enhances readability and maintainability of the RTOS codebase.
