### PR TITLE
Add Static Assertion for `CFN_MAX_PRI` in `config.h`

### DIFF
--- a/include/sys/config.h
+++ b/include/sys/config.h
@@ -13,6 +13,7 @@ extern "C" {
 
 /* Maximum task priority (also reflected in service profile item TK_MAX_TSKPRI)*/
 #define CFN_MAX_PRI 16
+_Static_assert(CFN_MAX_PRI >= 16, "CFN_MAX_PRI must be greater than or equal to 16, as required by TK_MAX_TSKPRI.");
 
 /* Lowest address of the area dynamically managed by uT-Kernel memory management function */
 // #define CFN_SYSTEMAREA_TOP 0


### PR DESCRIPTION
# Add Static Assertion for `CFN_MAX_PRI` in `config.h`

This pull request enhances the `config.h` header file by adding a static assertion to ensure that `CFN_MAX_PRI` meets the minimum required value.

## Changes

### Updated
- **`include/sys/config.h`**:
  - Added a `_Static_assert` for `CFN_MAX_PRI`:
    - Ensures `CFN_MAX_PRI` is at least 16, aligning with the requirement for `TK_MAX_TSKPRI`.
    - Includes a descriptive error message for clarity if the condition is not met.

### Rationale
- Provides compile-time validation to prevent misconfiguration of `CFN_MAX_PRI`.
- Ensures consistency with the service profile item `TK_MAX_TSKPRI`, reducing potential runtime errors.
- Improves code safety and maintainability by enforcing critical constraints early.
