### PR TITLE
Add `.cmake-format.yml` and Refactor CMake Scripts for Readability and Maintainability

### DIFF
--- a/.cmake-format.yml
+++ b/.cmake-format.yml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 Daisuke Nagao
+#
+# SPDX-License-Identifier: CC0-1.0
+markup:
+  markup_enable: false

--- a/.cmake-format.yml
+++ b/.cmake-format.yml
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 markup:
-  markup_enable: false
+    first_comment_is_literal: true 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,13 @@ add_executable(${EXECUTABLE})
 
 target_sources(
   ${EXECUTABLE}
-  PRIVATE kernel/asm/rv32/start.s kernel/asm/rv32/launch_task.s
-          kernel/asm/rv32/context_switch.s kernel/start.c kernel/task.c task1.c task2.c)
+  PRIVATE kernel/asm/rv32/start.s
+          kernel/asm/rv32/launch_task.s
+          kernel/asm/rv32/context_switch.s
+          kernel/start.c
+          kernel/task.c
+          task1.c
+          task2.c)
 
 # Set CMake compilation flags
 target_compile_options(
@@ -53,8 +58,10 @@ else()
     WARNING "Size command not found. Size information will not be available.")
 endif()
 
+# ~~~
 # Define options
-#option(TK_HAS_DOUBLEWORD "Enable 64-bit types" ON)
+# option(TK_HAS_DOUBLEWORD "Enable 64-bit types" ON)
+# ~~~
 
 # Include external script
 include(DetermineTypes.cmake)
@@ -62,5 +69,7 @@ include(DetermineTypes.cmake)
 # Generate typedef.h
 configure_file(typedef.h.in ${CMAKE_BINARY_DIR}/include/tk/typedef.h @ONLY)
 
+# ~~~
 # Add compile definitions based on options
-#target_compile_definitions(${EXECUTABLE} PUBLIC TK_HAS_DOUBLEWORD)
+# target_compile_definitions(${EXECUTABLE} PUBLIC TK_HAS_DOUBLEWORD)
+# ~~~

--- a/DetermineTypes.cmake
+++ b/DetermineTypes.cmake
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+# ~~~
 # DetermineTypes.cmake
 # Script to check type sizes and assign appropriate types
+# ~~~
 
 include(CheckTypeSize)
 
@@ -23,24 +25,44 @@ message(STATUS "long long size: ${LONG_LONG_SIZE}")
 
 # Function to assign types based on size
 function(assign_type target_size var_signed var_unsigned)
-    if(CHAR_SIZE EQUAL ${target_size})
-        set(${var_signed} "signed char" PARENT_SCOPE)
-        set(${var_unsigned} "unsigned char" PARENT_SCOPE)
-    elseif(SHORT_SIZE EQUAL ${target_size})
-        set(${var_signed} "signed short" PARENT_SCOPE)
-        set(${var_unsigned} "unsigned short" PARENT_SCOPE)
-    elseif(INT_SIZE EQUAL ${target_size})
-        set(${var_signed} "signed int" PARENT_SCOPE)
-        set(${var_unsigned} "unsigned int" PARENT_SCOPE)
-    elseif(LONG_SIZE EQUAL ${target_size})
-        set(${var_signed} "signed long" PARENT_SCOPE)
-        set(${var_unsigned} "unsigned long" PARENT_SCOPE)
-    elseif(LONG_LONG_SIZE EQUAL ${target_size})
-        set(${var_signed} "signed long long" PARENT_SCOPE)
-        set(${var_unsigned} "unsigned long long" PARENT_SCOPE)
-    else()
-        message(FATAL_ERROR "No ${target_size}-bit type available")
-    endif()
+  if(CHAR_SIZE EQUAL ${target_size})
+    set(${var_signed}
+        "signed char"
+        PARENT_SCOPE)
+    set(${var_unsigned}
+        "unsigned char"
+        PARENT_SCOPE)
+  elseif(SHORT_SIZE EQUAL ${target_size})
+    set(${var_signed}
+        "signed short"
+        PARENT_SCOPE)
+    set(${var_unsigned}
+        "unsigned short"
+        PARENT_SCOPE)
+  elseif(INT_SIZE EQUAL ${target_size})
+    set(${var_signed}
+        "signed int"
+        PARENT_SCOPE)
+    set(${var_unsigned}
+        "unsigned int"
+        PARENT_SCOPE)
+  elseif(LONG_SIZE EQUAL ${target_size})
+    set(${var_signed}
+        "signed long"
+        PARENT_SCOPE)
+    set(${var_unsigned}
+        "unsigned long"
+        PARENT_SCOPE)
+  elseif(LONG_LONG_SIZE EQUAL ${target_size})
+    set(${var_signed}
+        "signed long long"
+        PARENT_SCOPE)
+    set(${var_unsigned}
+        "unsigned long long"
+        PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "No ${target_size}-bit type available")
+  endif()
 endfunction()
 
 # Assign types for each bit width


### PR DESCRIPTION
# Add `.cmake-format.yml` and Refactor CMake Scripts for Readability and Maintainability

This pull request introduces a `.cmake-format.yml` configuration file for consistent formatting of CMake scripts and applies refactoring across the CMake files for improved readability.

## Changes

### Added
- **`.cmake-format.yml`**:
  - Configures `cmake-format` to ensure consistent formatting.
  - Includes settings such as `first_comment_is_literal: true` to preserve the first comment in each file.

### Updated
- **`CMakeLists.txt`**:
  - Improved readability by:
    - Breaking long lines into multi-line statements.
    - Adding `~~~` sections to visually separate logical blocks.
    - Commenting out unused options (`TK_HAS_DOUBLEWORD`) with consistent styling.
  - Reformatted `target_sources` for better clarity.

- **`DetermineTypes.cmake`**:
  - Added `~~~` markers to organize sections.
  - Reformatted the `assign_type` function:
    - Improved indentation and readability of `set()` statements.
    - Aligned code style with the new formatting configuration.

### Rationale
- Improves the maintainability and consistency of CMake scripts by enforcing a standard format.
- Enhances the readability of scripts for better developer experience.
- Introduces clear visual separation of logical sections, making it easier to navigate the scripts.
