### PR TITLE
Refactor Task Management with Generic Double-Linked List Implementation

### DIFF
--- a/kernel/list.h
+++ b/kernel/list.h
@@ -25,6 +25,16 @@ static inline BOOL tkmc_list_empty(const tkmc_list_head *head) {
   return head == head->next ? TRUE : FALSE;
 }
 
+#define tkmc_offsetof(type, member) ((unsigned long)&(((type *)0)->member))
+
+#define tkmc_container_of(ptr, type, member)                                   \
+  ((type *)((char *)(ptr) - tkmc_offsetof(type, member)))
+
+#define tkmc_list_entry(ptr, type, member) tkmc_container_of(ptr, type, member)
+
+#define tkmc_list_first_entry(ptr, type, member)                               \
+  tkmc_list_entry((ptr)->next, type, member)
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -35,6 +35,16 @@ static inline BOOL tkmc_list_empty(const tkmc_list_head *head) {
 #define tkmc_list_first_entry(ptr, type, member)                               \
   tkmc_list_entry((ptr)->next, type, member)
 
+static inline void tkmc_list_del(tkmc_list_head *head) {
+  tkmc_list_head *prev = head->prev;
+  tkmc_list_head *next = head->next;
+
+  prev->next = next;
+  next->prev = prev;
+
+  head->next = head->prev = (tkmc_list_head *)0xdeadbeef;
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UUID_0194C23B_B68F_7643_AA69_13C344A3D04F
+#define UUID_0194C23B_B68F_7643_AA69_13C344A3D04F
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* UUID_0194C23B_B68F_7643_AA69_13C344A3D04F */

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -45,6 +45,14 @@ static inline void tkmc_list_del(tkmc_list_head *head) {
   head->next = head->prev = (tkmc_list_head *)0xdeadbeef;
 }
 
+static inline void tkmc_list_add_tail(tkmc_list_head *new,
+                                      tkmc_list_head *head) {
+  new->next = head;
+  new->prev = head->prev;
+  new->prev->next = new;
+  head->prev = new;
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -16,9 +16,13 @@ typedef struct tkmc_list_head {
   struct tkmc_list_head *prev;
 } tkmc_list_head;
 
-static void tkmc_init_list_head(tkmc_list_head *head) {
+static inline void tkmc_init_list_head(tkmc_list_head *head) {
   head->next = head;
   head->prev = head;
+}
+
+static inline BOOL tkmc_list_empty(const tkmc_list_head *head) {
+  return head == head->next ? TRUE : FALSE;
 }
 
 #ifdef __cplusplus

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -11,6 +11,11 @@
 extern "C" {
 #endif /* __cplusplus */
 
+typedef struct tkmc_list_head {
+  struct tkmc_list_head *next;
+  struct tkmc_list_head *prev;
+} tkmc_list_head;
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -16,6 +16,11 @@ typedef struct tkmc_list_head {
   struct tkmc_list_head *prev;
 } tkmc_list_head;
 
+static void tkmc_init_list_head(tkmc_list_head *head) {
+  head->next = head;
+  head->prev = head;
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -25,8 +25,8 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
 
   ID new_id = E_LIMIT;
   TCB *new_tcb = NULL;
-  if (tkmc_list_empty(&tkmc_free_tcb.head) == FALSE) {
-    new_tcb = tkmc_list_first_entry(&tkmc_free_tcb.head, TCB, head);
+  if (tkmc_list_empty(&tkmc_free_tcb) == FALSE) {
+    new_tcb = tkmc_list_first_entry(&tkmc_free_tcb, TCB, head);
     tkmc_list_del(&new_tcb->head);
 
     new_id = new_tcb->tskid;

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -19,10 +19,6 @@ static UW task2_stack[1024];
 extern void __launch_task(void **sp_end);
 extern void __context_switch(void **next_sp, void **current_sp);
 
-#define tkmc_offsetof(type, member) ((unsigned long)&(((type *)0)->member))
-#define tkmc_container_of(ptr, type, member)                                   \
-  ((type *)((char *)(ptr) - tkmc_offsetof(type, member)))
-
 static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   UW *stack_begin = (UW *)sp;
   UW *stack_end = stack_begin + (stksz >> 2);
@@ -30,7 +26,8 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   ID new_id = E_LIMIT;
   TCB *new_tcb = NULL;
   if (tkmc_list_empty(&tkmc_free_tcb.head) == FALSE) {
-    new_tcb = tkmc_container_of(tkmc_free_tcb.head.next, TCB, head);
+    new_tcb = tkmc_list_first_entry(&tkmc_free_tcb.head, TCB, head);
+
     tkmc_free_tcb.head.next = new_tcb->head.next;
     new_tcb->head.next->prev = &tkmc_free_tcb.head;
     new_tcb->head.next = new_tcb->head.prev = (void *)0xdeadbeef;

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -27,10 +27,7 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
   TCB *new_tcb = NULL;
   if (tkmc_list_empty(&tkmc_free_tcb.head) == FALSE) {
     new_tcb = tkmc_list_first_entry(&tkmc_free_tcb.head, TCB, head);
-
-    tkmc_free_tcb.head.next = new_tcb->head.next;
-    new_tcb->head.next->prev = &tkmc_free_tcb.head;
-    new_tcb->head.next = new_tcb->head.prev = (void *)0xdeadbeef;
+    tkmc_list_del(&new_tcb->head);
 
     new_id = new_tcb->tskid;
   } else {

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -29,7 +29,7 @@ static ID tkmc_create_task(void *sp, SZ stksz, FP fp) {
 
   ID new_id = E_LIMIT;
   TCB *new_tcb = NULL;
-  if (&tkmc_free_tcb.head != tkmc_free_tcb.head.next) {
+  if (tkmc_list_empty(&tkmc_free_tcb.head) == FALSE) {
     new_tcb = tkmc_container_of(tkmc_free_tcb.head.next, TCB, head);
     tkmc_free_tcb.head.next = new_tcb->head.next;
     new_tcb->head.next->prev = &tkmc_free_tcb.head;

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -6,6 +6,8 @@
 
 #include "task.h"
 
+#include "list.h"
+
 TCB tkmc_tcbs[CFN_MAX_TSKID];
 TCB tkmc_free_tcb;
 TCB *current = NULL;

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -11,21 +11,17 @@ TCB tkmc_free_tcb;
 TCB *current = NULL;
 
 void tkmc_init_tcb(void) {
-  tkmc_free_tcb.head.next = tkmc_free_tcb.head.prev = &tkmc_free_tcb.head;
+  tkmc_init_list_head(&tkmc_free_tcb.head);
 
   for (int i = 0; i < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]); ++i) {
     TCB *tcb = &tkmc_tcbs[i];
     *tcb = (TCB){
-        .head =
-            (tkmc_list_head){
-                .next = &tcb->head,
-                .prev = &tcb->head,
-            },
         .tskid = i + 1,
         .state = NON_EXISTENT,
         .sp = NULL,
         .task = NULL,
     };
+    tkmc_init_list_head(&tcb->head);
 
     tkmc_free_tcb.head.prev->next = &tcb->head;
     tcb->head.prev = tkmc_free_tcb.head.prev;

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -23,9 +23,6 @@ void tkmc_init_tcb(void) {
     };
     tkmc_init_list_head(&tcb->head);
 
-    tkmc_free_tcb.prev->next = &tcb->head;
-    tcb->head.prev = tkmc_free_tcb.prev;
-    tcb->head.next = &tkmc_free_tcb;
-    tkmc_free_tcb.prev = &tcb->head;
+    tkmc_list_add_tail(&tcb->head, &tkmc_free_tcb);
   }
 }

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -6,29 +6,30 @@
 
 #include "task.h"
 
-#include "list.h"
-
 TCB tkmc_tcbs[CFN_MAX_TSKID];
 TCB tkmc_free_tcb;
 TCB *current = NULL;
 
 void tkmc_init_tcb(void) {
-  tkmc_free_tcb.next = tkmc_free_tcb.prev = &tkmc_free_tcb;
+  tkmc_free_tcb.head.next = tkmc_free_tcb.head.prev = &tkmc_free_tcb.head;
 
   for (int i = 0; i < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]); ++i) {
     TCB *tcb = &tkmc_tcbs[i];
     *tcb = (TCB){
-        .next = tcb,
-        .prev = tcb,
+        .head =
+            (tkmc_list_head){
+                .next = &tcb->head,
+                .prev = &tcb->head,
+            },
         .tskid = i + 1,
         .state = NON_EXISTENT,
         .sp = NULL,
         .task = NULL,
     };
 
-    tkmc_free_tcb.prev->next = tcb;
-    tcb->prev = tkmc_free_tcb.prev;
-    tcb->next = &tkmc_free_tcb;
-    tkmc_free_tcb.prev = tcb;
+    tkmc_free_tcb.head.prev->next = &tcb->head;
+    tcb->head.prev = tkmc_free_tcb.head.prev;
+    tcb->head.next = &tkmc_free_tcb.head;
+    tkmc_free_tcb.head.prev = &tcb->head;
   }
 }

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -7,11 +7,11 @@
 #include "task.h"
 
 TCB tkmc_tcbs[CFN_MAX_TSKID];
-TCB tkmc_free_tcb;
+tkmc_list_head tkmc_free_tcb;
 TCB *current = NULL;
 
 void tkmc_init_tcb(void) {
-  tkmc_init_list_head(&tkmc_free_tcb.head);
+  tkmc_init_list_head(&tkmc_free_tcb);
 
   for (int i = 0; i < sizeof(tkmc_tcbs) / sizeof(tkmc_tcbs[0]); ++i) {
     TCB *tcb = &tkmc_tcbs[i];
@@ -23,9 +23,9 @@ void tkmc_init_tcb(void) {
     };
     tkmc_init_list_head(&tcb->head);
 
-    tkmc_free_tcb.head.prev->next = &tcb->head;
-    tcb->head.prev = tkmc_free_tcb.head.prev;
-    tcb->head.next = &tkmc_free_tcb.head;
-    tkmc_free_tcb.head.prev = &tcb->head;
+    tkmc_free_tcb.prev->next = &tcb->head;
+    tcb->head.prev = tkmc_free_tcb.prev;
+    tcb->head.next = &tkmc_free_tcb;
+    tkmc_free_tcb.prev = &tcb->head;
   }
 }

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -9,6 +9,8 @@
 
 #include <tk/tkernel.h>
 
+#include "list.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -22,8 +24,7 @@ enum TaskState {
 
 /* Task Control Block */
 typedef struct TCB {
-  struct TCB *next;
-  struct TCB *prev;
+  tkmc_list_head head;
   ID tskid;
   enum TaskState state;
   void *sp;

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -32,7 +32,7 @@ typedef struct TCB {
 } TCB;
 
 extern TCB tkmc_tcbs[CFN_MAX_TSKID];
-extern TCB tkmc_free_tcb;
+extern tkmc_list_head tkmc_free_tcb;
 extern TCB *current;
 
 extern void tkmc_init_tcb(void);


### PR DESCRIPTION
This pull request introduces a generic double-linked list implementation for efficient task management in the RTOS kernel.

## Changes

### Added
- **`kernel/list.h`**:
  - Implemented a generic double-linked list (`tkmc_list_head`).
  - Provided utility functions:
    - `tkmc_init_list_head` - Initializes the list head.
    - `tkmc_list_empty` - Checks if the list is empty.
    - `tkmc_list_add_tail` - Adds a new element to the tail.
    - `tkmc_list_del` - Removes an element from the list.
    - `tkmc_list_entry`, `tkmc_container_of` - Retrieves the containing structure.

### Updated
- **`kernel/task.h`**:
  - Replaced raw `next`/`prev` pointers in `TCB` with `tkmc_list_head head` for list integration.

- **`kernel/task.c`**:
  - Refactored the free TCB list (`tkmc_free_tcb`) to use the new double-linked list API.
  - Simplified `tkmc_init_tcb` using `tkmc_list_add_tail` for managing the free list.

- **`kernel/start.c`**:
  - Refactored `tkmc_create_task` to allocate TCBs using `tkmc_list_first_entry` and `tkmc_list_del`.
  - Enhanced readability and robustness of the task creation logic.

### Benefits
- **Reusability**: The generic list can be reused in other kernel modules, improving code modularity.
- **Efficiency**: Optimized task allocation/deallocation with constant-time list operations.
- **Readability**: Simplified task management code, making it easier to maintain.

### Rationale
- Replacing custom TCB management with a standard list abstraction improves consistency and reduces potential bugs.
- Using `tkmc_list_head` ensures flexibility for future features, such as priority queues or task scheduling lists.
