### PR TITLE
Refactor Task Creation with `T_CTSK` Structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,11 @@ else()
     WARNING "Size command not found. Size information will not be available.")
 endif()
 
-# ~~~
 # Define options
-# option(TK_HAS_DOUBLEWORD "Enable 64-bit types" ON)
-# ~~~
+option(
+  TKERNEL_CHECK_CONST
+  "Enable CONST checks to prevent unintended modifications to pointer parameters in system calls. This helps ensure code safety by using 'const' qualifiers when supported. If disabled, CONST will be defined as an empty macro to maintain compatibility with legacy code."
+  ON)
 
 # Include external script
 include(DetermineTypes.cmake)
@@ -69,7 +70,7 @@ include(DetermineTypes.cmake)
 # Generate typedef.h
 configure_file(typedef.h.in ${CMAKE_BINARY_DIR}/include/tk/typedef.h @ONLY)
 
-# ~~~
 # Add compile definitions based on options
-# target_compile_definitions(${EXECUTABLE} PUBLIC TK_HAS_DOUBLEWORD)
-# ~~~
+if(TKERNEL_CHECK_CONST)
+  target_compile_definitions(${EXECUTABLE} PUBLIC TKERNEL_CHECK_CONST)
+endif()

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -9,9 +9,17 @@
 
 #include <sys/config.h>
 
+// clang-format off
 #include <tk/typedef.h>
+// clang-format on
 #include <tk/errno.h>
 
 #include <sys/profile.h>
+
+#ifdef TKERNEL_CHECK_CONST
+#define CONST const
+#else
+#define CONST
+#endif /* TKERNEL_CHECK_CONST */
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -18,7 +18,7 @@ static UW task2_stack[1024];
 
 extern void __launch_task(void **sp_end);
 
-extern ID tkmc_create_task(void *sp, SZ stksz, PRI itskpri, FP fp);
+extern ID tkmc_create_task(const T_CTSK *pk_ctsk);
 extern ER tkmc_start_task(ID tskid);
 extern TCB *tkmc_get_highest_priority_task(void);
 
@@ -27,10 +27,26 @@ void tkmc_start(int a0, int a1) {
 
   tkmc_init_tcb();
 
-  ID task1_id =
-      tkmc_create_task(task1_stack, sizeof(task1_stack), 1, (FP)task1);
-  ID task2_id =
-      tkmc_create_task(task2_stack, sizeof(task2_stack), 1, (FP)task2);
+  T_CTSK pk_ctsk1 = {
+      .task = task1,
+      .itskpri = 1,
+      .stksz = sizeof(task1_stack),
+      .bufptr = task1_stack,
+  };
+
+  T_CTSK pk_ctsk2 = {
+      .task = task2,
+      .itskpri = 1,
+      .stksz = sizeof(task2_stack),
+      .bufptr = task2_stack,
+  };
+  ID task1_id = tkmc_create_task(&pk_ctsk1);
+  ID task2_id = tkmc_create_task(&pk_ctsk2);
+
+  // ID task1_id =
+  //     tkmc_create_task(task1_stack, sizeof(task1_stack), 1, (FP)task1);
+  // ID task2_id =
+  //     tkmc_create_task(task2_stack, sizeof(task2_stack), 1, (FP)task2);
 
   tkmc_start_task(task1_id);
   tkmc_start_task(task2_id);

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -40,7 +40,7 @@ void tkmc_init_tcb(void) {
   }
 }
 
-ID tkmc_create_task(const T_CTSK *pk_ctsk) {
+ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
   UW *stack_begin = (UW *)pk_ctsk->bufptr;
   UW *stack_end = stack_begin + (pk_ctsk->stksz >> 2);
 

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -40,9 +40,9 @@ void tkmc_init_tcb(void) {
   }
 }
 
-ID tkmc_create_task(void *sp, SZ stksz, PRI itskpri, FP fp) {
-  UW *stack_begin = (UW *)sp;
-  UW *stack_end = stack_begin + (stksz >> 2);
+ID tkmc_create_task(const T_CTSK *pk_ctsk) {
+  UW *stack_begin = (UW *)pk_ctsk->bufptr;
+  UW *stack_end = stack_begin + (pk_ctsk->stksz >> 2);
 
   ID new_id = E_LIMIT;
   TCB *new_tcb = NULL;
@@ -61,10 +61,10 @@ ID tkmc_create_task(void *sp, SZ stksz, PRI itskpri, FP fp) {
     for (int i = 0; i < 12; ++i) {
       stack_end[i] = 0xdeadbeef;
     }
-    stack_end[12] = (UW)fp;
+    stack_end[12] = (UW)pk_ctsk->task;
     new_tcb->sp = stack_end;
-    new_tcb->task = fp;
-    new_tcb->itskpri = itskpri;
+    new_tcb->task = pk_ctsk->task;
+    new_tcb->itskpri = pk_ctsk->itskpri;
   } else {
     new_id = (ID)E_LIMIT;
   }

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -36,6 +36,13 @@ extern TCB *current;
 
 extern void tkmc_init_tcb(void);
 
+typedef struct T_CTSK {
+  FP task;      /* Task Start Address */
+  PRI itskpri;  /* Initial Task Priority */
+  SZ stksz;     /* Stack Size */
+  void *bufptr; /* Buffer Pointer */
+} T_CTSK;
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */


### PR DESCRIPTION
# Refactor Task Creation with `T_CTSK` Structure

## Overview

This pull request refactors the task creation process by introducing the `T_CTSK` structure. The new structure encapsulates task creation parameters, enhancing code readability, maintainability, and flexibility. This change also prepares the codebase for future extensions where additional task attributes might be required.

## Key Changes

- **Introduced `T_CTSK` Structure (`task.h`):**
  - Defines task attributes:
    - `FP task`: Task entry point
    - `PRI itskpri`: Initial task priority
    - `SZ stksz`: Stack size
    - `void *bufptr`: Stack buffer pointer

- **Refactored `tkmc_create_task` (`task.c`):**
  - Replaced multiple parameters with a single `CONST T_CTSK *pk_ctsk` argument.
  - Improved memory layout clarity by centralizing task-related data.

- **Updated Task Initialization (`start.c`):**
  - Replaced raw task creation calls with structured initialization using `T_CTSK`.
  - Enhanced the readability of the startup code.

- **CMake Update (`CMakeLists.txt`):**
  - Added the `TKERNEL_CHECK_CONST` option to enable or disable `const` checks for pointer parameters, ensuring backward compatibility when needed.

## Motivation

- **Improved Maintainability:** Centralizing task parameters reduces the risk of mismatched arguments during task creation.
- **Scalability:** Future task attributes can be added to `T_CTSK` without modifying function signatures.
- **Code Clarity:** Makes the intent of task creation more explicit, improving code readability.

## Example of New Task Creation

````c
T_CTSK pk_ctsk1 = {
    .task = task1,
    .itskpri = 1,
    .stksz = sizeof(task1_stack),
    .bufptr = task1_stack,
};
ID task1_id = tkmc_create_task(&pk_ctsk1);
````

## Backward Compatibility

- The introduction of `T_CTSK` is designed to be non-disruptive, but legacy task creation calls must be updated to the new format.
- The `TKERNEL_CHECK_CONST` option allows disabling `const` checks if needed for older code.

## Testing

- Verified task creation, context switching, and priority scheduling.
- Ensured builds succeed with both `TKERNEL_CHECK_CONST` enabled and disabled.
