### PR TITLE
Add `tskatr` to `T_CTSK` for Task Attribute Support

### DIFF
--- a/kernel/start.c
+++ b/kernel/start.c
@@ -32,6 +32,7 @@ void tkmc_start(int a0, int a1) {
 
   T_CTSK pk_ctsk1 = {
       .exinf = (void *)hello_world,
+      .tskatr = TA_USERBUF,
       .task = (FP)task1,
       .itskpri = 1,
       .stksz = sizeof(task1_stack),
@@ -40,6 +41,7 @@ void tkmc_start(int a0, int a1) {
 
   T_CTSK pk_ctsk2 = {
       .exinf = (void *)fizzbuzz,
+      .tskatr = TA_USERBUF,
       .task = (FP)task1,
       .itskpri = 1,
       .stksz = sizeof(task2_stack),

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -39,6 +39,17 @@ void tkmc_init_tcb(void) {
 }
 
 ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
+  const ATR tskatr = pk_ctsk->tskatr;
+  static const ATR VALID_TSKATR =
+      TA_ASM | TA_HLNG | TA_USERBUF | TA_RNG0 | TA_RNG1 | TA_RNG2 | TA_RNG3;
+  if ((tskatr & ~VALID_TSKATR) != 0) {
+    return E_RSATR;
+  }
+
+  if ((tskatr & TA_USERBUF) == 0) {
+    return E_RSATR;
+  }
+
   UW *stack_begin = (UW *)pk_ctsk->bufptr;
   UW *stack_end = stack_begin + (pk_ctsk->stksz >> 2);
 

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -84,12 +84,22 @@ ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
 }
 
 ER tkmc_start_task(ID tskid, INT stacd) {
+  if (tskid >= CFN_MAX_TSKID) {
+    return E_ID;
+  }
   TCB *tcb = tkmc_tcbs + tskid - 1;
+  if (tcb->state == NON_EXISTENT) {
+    return E_NOEXS;
+  }
+  if (tcb->state != DORMANT) {
+    return E_OBJ;
+  }
+
   tcb->state = READY;
 
   PRI itskpri = tcb->itskpri;
   INT *sp = (INT *)tcb->sp;
-  sp[6] = stacd; /* a0 register */
+  sp[6] = stacd;           /* a0 register */
   sp[7] = (INT)tcb->exinf; /* a1 register */
   tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[itskpri - 1]);
   return E_OK;

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -15,6 +15,21 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#define TA_ASM 0x00000000UL     /* Program by assembler */
+#define TA_HLNG 0x00000001UL    /* Program by high level programming language */
+#define TA_USERBUF 0x00000020UL /* Specify user buffer */
+#define TA_DSNAME 0x00000040UL  /* Use object name */
+
+#define TA_RNG0 0x00000000UL /* Execute by protection level 0 */
+#define TA_RNG1 0x00000100UL /* Execute by protection level 1 */
+#define TA_RNG2 0x00000200UL /* Execute by protection level 2 */
+#define TA_RNG3 0x00000300UL /* Execute by protection level 3 */
+
+#define TA_COP0 0x00001000U /* Use coprocessor (ID=0) */
+#define TA_COP1 0x00002000U /* Use coprocessor (ID=1) */
+#define TA_COP2 0x00004000U /* Use coprocessor (ID=2) */
+#define TA_COP3 0x00008000U /* Use coprocessor (ID=3) */
+
 enum TaskState {
   NON_EXISTENT = 0,
   DORMANT,
@@ -39,6 +54,7 @@ extern void tkmc_init_tcb(void);
 
 typedef struct T_CTSK {
   void *exinf;  /* Extended Information */
+  ATR tskatr;   /* Task Attribute  */
   FP task;      /* Task Start Address */
   PRI itskpri;  /* Initial Task Priority */
   SZ stksz;     /* Stack Size */


### PR DESCRIPTION
## Description

This pull request introduces task attributes (`tskatr`) to `T_CTSK`, enabling support for task-specific configurations. The addition of `tskatr` allows tasks to specify execution attributes such as user-defined stack buffers, privilege levels, and execution modes.

### Changes

#### 1. Introduce `tskatr` to `T_CTSK`
- `tskatr` is added to `T_CTSK`, allowing tasks to specify attributes.
- Existing task creation calls (`tkmc_create_task`) are updated to include `tskatr`, ensuring correct task initialization.

#### 2. Define Task Attributes (`ATR`)
- Task attributes are defined using `#define` macros, allowing fine-grained control over task execution:
  - `TA_ASM`, `TA_HLNG`: Specifies if the task is written in assembler or high-level language.
  - `TA_USERBUF`: Requires the task to provide its own stack buffer.
  - `TA_RNG0–TA_RNG3`: Defines execution privilege levels.
  - `TA_COP0–TA_COP3`: Specifies coprocessor usage.

#### 3. Add Attribute Validation in `tkmc_create_task`
- Ensures that only valid attributes are set.
- Verifies that `TA_USERBUF` is present; if absent, `E_RSATR` is returned.

#### 4. Improve Error Handling in `tkmc_start_task`
- Returns `E_ID` for invalid task IDs.
- Returns `E_NOEXS` if the task does not exist.
- Returns `E_OBJ` if the task is not in the `DORMANT` state.

### Implementation Overview

#### Updated `T_CTSK` Structure
````c
typedef struct T_CTSK {
    void *exinf;  /* Extended Information */
    ATR tskatr;   /* Task Attribute */
    FP task;      /* Task Start Address */
    PRI itskpri;  /* Initial Task Priority */
    SZ stksz;     /* Stack Size */
    void *bufptr; /* Buffer Pointer */
} T_CTSK;
````

#### Attribute Validation in `tkmc_create_task`
````c
ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
    const ATR tskatr = pk_ctsk->tskatr;
    static const ATR VALID_TSKATR =
        TA_ASM | TA_HLNG | TA_USERBUF | TA_RNG0 | TA_RNG1 | TA_RNG2 | TA_RNG3;
    
    if ((tskatr & ~VALID_TSKATR) != 0) {
        return E_RSATR;
    }
    if ((tskatr & TA_USERBUF) == 0) {
        return E_RSATR;
    }
    
    ...
}
````

#### Task Start Validations
````c
ER tkmc_start_task(ID tskid, INT stacd) {
    if (tskid >= CFN_MAX_TSKID) {
        return E_ID;
    }
    TCB *tcb = tkmc_tcbs + tskid - 1;
    if (tcb->state == NON_EXISTENT) {
        return E_NOEXS;
    }
    if (tcb->state != DORMANT) {
        return E_OBJ;
    }
    
    tcb->state = READY;
    INT *sp = (INT *)tcb->sp;
    sp[6] = stacd;           /* a0 register */
    sp[7] = (INT)tcb->exinf; /* a1 register */
    
    tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[tcb->itskpri - 1]);
    return E_OK;
}
````

### Expected Benefits
- **Enhances Task Flexibility**: Allows tasks to specify execution characteristics.
- **Ensures Attribute Validity**: Prevents unsupported or invalid configurations.
- **Improves Robustness**: Adds stricter error handling for task creation and execution.
- **Aligns with uT-Kernel Specification**: Follows standard task attribute conventions.

### Verification
- Verified that tasks correctly use `tskatr` during creation.
- Confirmed that incorrect attributes return `E_RSATR` as expected.
- Ensured that task startup validations prevent incorrect transitions.
