### PR TITLE
Implement `tk_ext_tsk` to Allow a Task to Terminate Itself

### DIFF
--- a/kernel/task.c
+++ b/kernel/task.c
@@ -132,3 +132,12 @@ void tkmc_yield(void) {
     out_w(0x2000000, 1); // Trigger a machine software interrupt
   }
 }
+
+void tkmc_ext_tsk(void) {
+  TCB *tmp = current;
+  tkmc_list_del(&tmp->head);
+  tmp->state = DORMANT;
+  TCB *top = tkmc_get_highest_priority_task();
+  top->state = RUNNING;
+  out_w(0x2000000, 1); // Trigger a machine software interrupt
+}


### PR DESCRIPTION
# Title: Implement `tk_ext_tsk` to Allow a Task to Terminate Itself

## Description

This pull request introduces the `tk_ext_tsk` functionality, allowing a task to terminate itself (`tkmc_ext_tsk`). This is an essential feature for task lifecycle management, enabling tasks to cleanly exit and allow other tasks to take over.

### Changes

#### 1. Implement `tkmc_ext_tsk`
- The function `tkmc_ext_tsk` allows the currently running task to remove itself from the ready queue and transition to the `DORMANT` state.
- The highest-priority task from the ready queue is selected as the next task to execute.
- A machine software interrupt is triggered to switch context.

#### 2. Introduce `task3` to Test `tkmc_ext_tsk`
- `task3` is created as a new test task that executes 10 times before calling `tkmc_ext_tsk`.
- The task prints `"task3"` to the console before yielding.
- After 10 iterations, it calls `tkmc_ext_tsk` to terminate itself.

#### 3. Update Task Initialization
- `task3` is added to `tkmc_start`, with a new stack and task creation parameters.
- The task is scheduled with priority `1`.

### Implementation Overview

#### `tkmc_ext_tsk` Implementation
````c
void tkmc_ext_tsk(void) {
    TCB *tmp = current;
    tkmc_list_del(&tmp->head);
    tmp->state = DORMANT;

    TCB *top = tkmc_get_highest_priority_task();
    top->state = RUNNING;

    out_w(0x2000000, 1); // Trigger a machine software interrupt
}
````

#### `task3` Implementation
````c
void task3(INT stcd, void *exinf) {
    extern void tkmc_yield(void);
    for (int i = 0; i < 10; ++i) {
        putstring("task3\n");
        tkmc_yield();
    }
    tkmc_ext_tsk();
}
````

#### Task Initialization in `tkmc_start`
````c
T_CTSK pk_ctsk3 = {
    .exinf = NULL,
    .tskatr = TA_USERBUF,
    .task = (FP)task3,
    .itskpri = 1,
    .stksz = sizeof(task3_stack),
    .bufptr = task3_stack,
};
ID task3_id = tkmc_create_task(&pk_ctsk3);
tkmc_start_task(task3_id, 3);
````

### Expected Benefits
- **Enables Task Termination**: Allows a task to exit gracefully.
- **Improves Task Lifecycle Management**: Tasks can self-terminate without external intervention.
- **Ensures Context Switch After Termination**: The highest-priority ready task is scheduled immediately.
- **Simplifies Future Enhancements**: Provides a foundation for more advanced task management operations.

### Verification
- `task3` was tested to confirm that it correctly prints `"task3"` ten times before terminating.
- The system correctly switches to the highest-priority ready task after `task3` exits.
