### PR TITLE
Introduce Initial Task (`ini_tsk`) and `usermain` for Application Entry Point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${EXECUTABLE})
 
 target_sources(
   ${EXECUTABLE} PRIVATE kernel/asm/rv32/start.s kernel/asm/rv32/launch_task.s
-                        kernel/start.c kernel/task.c task1.c)
+                        kernel/start.c kernel/task.c kernel/ini_tsk.c task1.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,14 @@ set(COMMON_FLAGS -ffreestanding -nostdlib)
 add_executable(${EXECUTABLE})
 
 target_sources(
-  ${EXECUTABLE} PRIVATE kernel/asm/rv32/start.s kernel/asm/rv32/launch_task.s
-                        kernel/start.c kernel/task.c kernel/ini_tsk.c task1.c)
+  ${EXECUTABLE}
+  PRIVATE kernel/asm/rv32/start.s
+          kernel/asm/rv32/launch_task.s
+          kernel/start.c
+          kernel/task.c
+          kernel/ini_tsk.c
+          kernel/usermain.c
+          task1.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/kernel/ini_tsk.c
+++ b/kernel/ini_tsk.c
@@ -5,3 +5,5 @@
  */
 
 #include "ini_tsk.h"
+
+void tkmc_ini_tsk(INT stacd, void *exinf) {}

--- a/kernel/ini_tsk.c
+++ b/kernel/ini_tsk.c
@@ -6,4 +6,12 @@
 
 #include "ini_tsk.h"
 
-void tkmc_ini_tsk(INT stacd, void *exinf) {}
+extern void usermain(int _a0);
+extern void tkmc_yield(void);
+
+void tkmc_ini_tsk(INT stacd, void *exinf) {
+  usermain(stacd);
+  while (1) {
+    tkmc_yield();
+  }
+}

--- a/kernel/ini_tsk.c
+++ b/kernel/ini_tsk.c
@@ -7,11 +7,9 @@
 #include "ini_tsk.h"
 
 extern void usermain(int _a0);
-extern void tkmc_yield(void);
+extern void tkmc_ext_tsk(void);
 
 void tkmc_ini_tsk(INT stacd, void *exinf) {
   usermain(stacd);
-  while (1) {
-    tkmc_yield();
-  }
+  tkmc_ext_tsk();
 }

--- a/kernel/ini_tsk.c
+++ b/kernel/ini_tsk.c
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "ini_tsk.h"

--- a/kernel/ini_tsk.h
+++ b/kernel/ini_tsk.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UUID_019519B3_2872_7971_A6E8_43F380E8BC08
+#define UUID_019519B3_2872_7971_A6E8_43F380E8BC08
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* UUID_019519B3_2872_7971_A6E8_43F380E8BC08 */

--- a/kernel/ini_tsk.h
+++ b/kernel/ini_tsk.h
@@ -7,9 +7,13 @@
 #ifndef UUID_019519B3_2872_7971_A6E8_43F380E8BC08
 #define UUID_019519B3_2872_7971_A6E8_43F380E8BC08
 
+#include <tk/tkernel.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+extern void tkmc_ini_tsk(INT stacd, void *exinf);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -6,15 +6,12 @@
 
 #include <tk/tkernel.h>
 
+#include "ini_tsk.h"
 #include "task.h"
 
 static void clear_bss(void);
 
-extern void task1(INT stacd, void *exinf);
-extern void task2(INT stacd, void *exinf);
-
-static UW task1_stack[1024];
-static UW task2_stack[1024];
+static UINT ini_tsk_stack[128] __attribute__((aligned(16)));
 
 extern void __launch_task(void **sp_end);
 
@@ -22,36 +19,22 @@ extern ID tkmc_create_task(const T_CTSK *pk_ctsk);
 extern ER tkmc_start_task(ID tskid, INT stacd);
 extern TCB *tkmc_get_highest_priority_task(void);
 
-static const char hello_world[] = "Hello, world.";
-static const char fizzbuzz[] = "FizzBuzz.";
-
 void tkmc_start(int a0, int a1) {
   clear_bss();
 
   tkmc_init_tcb();
 
-  T_CTSK pk_ctsk1 = {
-      .exinf = (void *)hello_world,
+  T_CTSK pk_ctsk = {
+      .exinf = NULL,
       .tskatr = TA_USERBUF,
-      .task = (FP)task1,
+      .task = (FP)tkmc_ini_tsk,
       .itskpri = 1,
-      .stksz = sizeof(task1_stack),
-      .bufptr = task1_stack,
+      .stksz = sizeof(ini_tsk_stack),
+      .bufptr = ini_tsk_stack,
   };
 
-  T_CTSK pk_ctsk2 = {
-      .exinf = (void *)fizzbuzz,
-      .tskatr = TA_USERBUF,
-      .task = (FP)task1,
-      .itskpri = 1,
-      .stksz = sizeof(task2_stack),
-      .bufptr = task2_stack,
-  };
-  ID task1_id = tkmc_create_task(&pk_ctsk1);
-  ID task2_id = tkmc_create_task(&pk_ctsk2);
-
-  tkmc_start_task(task1_id, 1);
-  tkmc_start_task(task2_id, 2);
+  ID ini_tsk_id = tkmc_create_task(&pk_ctsk);
+  tkmc_start_task(ini_tsk_id, a0);
 
   TCB *tcb = tkmc_get_highest_priority_task();
   tcb->state = RUNNING;

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -4,5 +4,45 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <tk/tkernel.h>
+
+#include "task.h"
+
+extern void task1(INT stacd, void *exinf);
+extern void task2(INT stacd, void *exinf);
+
+static UW task1_stack[1024] __attribute__((aligned(16)));
+static UW task2_stack[1024] __attribute__((aligned(16)));
+
+static const char hello_world[] = "Hello, world.";
+static const char fizzbuzz[] = "FizzBuzz.";
+
+extern ID tkmc_create_task(const T_CTSK *pk_ctsk);
+extern ER tkmc_start_task(ID tskid, INT stacd);
+
 void usermain(int _a0) __attribute__((weak));
-void usermain(int _a0) {}
+void usermain(int _a0) {
+
+  T_CTSK pk_ctsk1 = {
+      .exinf = (void *)hello_world,
+      .tskatr = TA_USERBUF,
+      .task = (FP)task1,
+      .itskpri = 1,
+      .stksz = sizeof(task1_stack),
+      .bufptr = task1_stack,
+  };
+
+  T_CTSK pk_ctsk2 = {
+      .exinf = (void *)fizzbuzz,
+      .tskatr = TA_USERBUF,
+      .task = (FP)task1,
+      .itskpri = 1,
+      .stksz = sizeof(task2_stack),
+      .bufptr = task2_stack,
+  };
+  ID task1_id = tkmc_create_task(&pk_ctsk1);
+  ID task2_id = tkmc_create_task(&pk_ctsk2);
+
+  tkmc_start_task(task1_id, 1);
+  tkmc_start_task(task2_id, 2);
+}

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -27,7 +27,7 @@ void usermain(int _a0) {
       .exinf = (void *)hello_world,
       .tskatr = TA_USERBUF,
       .task = (FP)task1,
-      .itskpri = 1,
+      .itskpri = 2,
       .stksz = sizeof(task1_stack),
       .bufptr = task1_stack,
   };
@@ -36,7 +36,7 @@ void usermain(int _a0) {
       .exinf = (void *)fizzbuzz,
       .tskatr = TA_USERBUF,
       .task = (FP)task1,
-      .itskpri = 1,
+      .itskpri = 2,
       .stksz = sizeof(task2_stack),
       .bufptr = task2_stack,
   };

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+void usermain(int _a0) __attribute__((weak));
+void usermain(int _a0) {}


### PR DESCRIPTION
# Title: Introduce Initial Task (`ini_tsk`) and `usermain` for Application Entry Point

## Description

This pull request refactors the system initialization process by introducing an initial task (`ini_tsk`), which serves as the first user-defined task upon system startup. The new `usermain` function provides a dedicated entry point for user applications, improving modularity and separation between system and user-level task management.

### Key Changes

#### 1. Introduce `ini_tsk`
- A new task, `ini_tsk`, is created at system startup to invoke `usermain`.
- `ini_tsk` executes `usermain` and then calls `tkmc_ext_tsk` to terminate itself.
- This change provides a clean separation between system initialization and user application logic.

#### 2. Implement `usermain`
- `usermain` is a weakly defined function that users can override to define their application logic.
- The default implementation in `kernel/usermain.c` initializes and starts `task1` and `task2`.

#### 3. Modify `tkmc_start` to Use `ini_tsk`
- Instead of creating multiple tasks in `tkmc_start`, a single initial task (`ini_tsk`) is created and started.
- The system now boots into `ini_tsk`, which then calls `usermain`.

#### 4. Remove Direct Task Initialization from `tkmc_start`
- `task1` and `task2` are now created inside `usermain`, ensuring better separation of system and user logic.

### Implementation Overview

#### `ini_tsk.c`
````c
void tkmc_ini_tsk(INT stacd, void *exinf) {
    usermain(stacd);
    tkmc_ext_tsk();
}
````

#### `usermain.c`
````c
void usermain(int _a0) __attribute__((weak));
void usermain(int _a0) {
    T_CTSK pk_ctsk1 = {
        .exinf = (void *)hello_world,
        .tskatr = TA_USERBUF,
        .task = (FP)task1,
        .itskpri = 2,
        .stksz = sizeof(task1_stack),
        .bufptr = task1_stack,
    };

    T_CTSK pk_ctsk2 = {
        .exinf = (void *)fizzbuzz,
        .tskatr = TA_USERBUF,
        .task = (FP)task1,
        .itskpri = 2,
        .stksz = sizeof(task2_stack),
        .bufptr = task2_stack,
    };

    ID task1_id = tkmc_create_task(&pk_ctsk1);
    ID task2_id = tkmc_create_task(&pk_ctsk2);

    tkmc_start_task(task1_id, 1);
    tkmc_start_task(task2_id, 2);
}
````

#### `tkmc_start` Modifications
````c
T_CTSK pk_ctsk = {
    .exinf = NULL,
    .tskatr = TA_USERBUF,
    .task = (FP)tkmc_ini_tsk,
    .itskpri = 1,
    .stksz = sizeof(ini_tsk_stack),
    .bufptr = ini_tsk_stack,
};
ID ini_tsk_id = tkmc_create_task(&pk_ctsk);
tkmc_start_task(ini_tsk_id, a0);
````

### Benefits
- **Improved Modularity**: Clean separation between system initialization and user application logic.
- **Flexible User Application Entry**: Users can override `usermain` to define their own task initialization.
- **Better Maintainability**: Encapsulating user task creation in `usermain` simplifies future modifications.
- **More Structured System Boot Process**: The system now follows a structured initialization, starting with `ini_tsk`, which invokes `usermain`.

### Verification
- Verified that `task1` and `task2` are created and started as expected.
- Ensured `ini_tsk` correctly calls `usermain` and terminates afterward.
- Tested overriding `usermain` with a custom implementation to confirm flexibility.
