### PR TITLE
Align Task Context Switching with RISC-V Calling Convention

### DIFF
--- a/kernel/asm/rv32/launch_task.s
+++ b/kernel/asm/rv32/launch_task.s
@@ -36,5 +36,5 @@ __launch_task:
     lw t1, 2*4(sp)
     lw t0, 1*4(sp)
     lw ra, 0*4(sp)
-    addi  sp, sp, 4*29
+    addi  sp, sp, 4*32
     ret

--- a/kernel/asm/rv32/start.s
+++ b/kernel/asm/rv32/start.s
@@ -27,7 +27,7 @@ _start:
 
   .balign 4
 mtrap_handler:
-  addi sp, sp, -29*4
+  addi sp, sp, -32*4
 
   sw ra, 0*4(sp)
   sw t0, 1*4(sp)
@@ -102,7 +102,7 @@ mtrap_handler:
   lw t0, 1*4(sp)
   lw ra, 0*4(sp)
 
-  addi sp, sp, 29*4
+  addi sp, sp, 32*4
   mret
 
   .balign 4

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -66,8 +66,8 @@ ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
 
   if (new_id >= 0) {
     new_tcb->state = DORMANT;
-    stack_end += -29;
-    for (int i = 0; i < 29; ++i) {
+    stack_end += -32;
+    for (int i = 0; i < 32; ++i) {
       stack_end[i] = 0xdeadbeef;
     }
     stack_end[0] = (UW)pk_ctsk->task;


### PR DESCRIPTION

## Description

This pull request updates the task context switching mechanism to align with the RISC-V calling convention. The primary change ensures proper stack pointer alignment and sufficient space allocation for saving all required registers.

### Key Changes

#### 1. Adjust Stack Space Allocation
- The stack pointer is now adjusted by `32 * 4` bytes instead of `29 * 4` to properly accommodate all registers that need to be saved during context switching.
- This change ensures that context switching follows the RISC-V **calling convention**, preventing misalignment issues.

#### 2. Update `launch_task.s`
- The stack cleanup operation at the end of `__launch_task` now restores **32 words** instead of **29 words**, ensuring proper alignment.
  
````assembly
    addi  sp, sp, 4*32
    ret
````

#### 3. Modify `start.s` Interrupt Handler
- The machine trap (`mtrap_handler`) now allocates and restores **32 words** instead of **29**, aligning with the expected stack frame size.

````assembly
    addi sp, sp, -32*4  // Allocate space for context save
    ...
    addi sp, sp, 32*4   // Restore stack pointer before returning
    mret
````

#### 4. Fix Stack Frame in `task.c`
- The initial stack frame allocation now reserves **32 slots** instead of **29** for each task.

````c
    stack_end += -32;
    for (int i = 0; i < 32; ++i) {
        stack_end[i] = 0xdeadbeef;
    }
````

### Benefits
- **Ensures RISC-V Compliance**: The update properly aligns the stack for context switching, following the RISC-V ABI.
- **Fixes Potential Misalignment Issues**: Previously, the stack allocation was insufficient for a complete context save/restore.
- **Improves System Stability**: Prevents unexpected behavior caused by improper stack management in interrupt handlers and task switching.

### Verification
- Verified that tasks switch correctly and stack pointers remain aligned.
- Checked that interrupt handling (`mtrap_handler`) correctly saves and restores registers without corruption.
- Ensured all modifications adhere to the RISC-V calling convention.
