### PR TITLE
Ensure safe termination of tasks by redirecting return to tkmc_ext_tsk

### DIFF
--- a/kernel/asm/rv32/launch_task.s
+++ b/kernel/asm/rv32/launch_task.s
@@ -36,5 +36,6 @@ __launch_task:
     lw t1, 2*4(sp)
     lw t0, 1*4(sp)
     lw ra, 0*4(sp)
+    lw a3, 28*4(sp)
     addi  sp, sp, 4*32
-    ret
+    jalr x0, a3, 0

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -5,6 +5,7 @@
  */
 
 #include "task.h"
+extern void tkmc_ext_tsk(void);
 
 TCB tkmc_tcbs[CFN_MAX_TSKID];
 tkmc_list_head tkmc_free_tcb;
@@ -70,8 +71,8 @@ ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
     for (int i = 0; i < 32; ++i) {
       stack_end[i] = 0xdeadbeef;
     }
-    stack_end[0] = (UW)pk_ctsk->task;
-    stack_end[28] = (UW)pk_ctsk->task;
+    stack_end[0] = (UW)tkmc_ext_tsk;   /* ra */
+    stack_end[28] = (UW)pk_ctsk->task; /* mepc */
     new_tcb->sp = stack_end;
     new_tcb->task = pk_ctsk->task;
     new_tcb->itskpri = pk_ctsk->itskpri;


### PR DESCRIPTION
- Modified `__launch_task` to use `jalr x0, a3, 0` instead of `ret` to ensure safe task termination.
- Adjusted task stack setup in `tkmc_create_task`:
  - Set `stack_end[0]` (ra) to `tkmc_ext_tsk` to redirect task return.
  - Set `stack_end[28]` (mepc) to the actual task entry point.