### PR TITLE
Implement `DI` and `EI` Macros for Interrupt Control

### DIFF
--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -1,9 +1,32 @@
 #ifndef UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
 #define UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
 
+#include <tk/typedef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+#define MSTATUS_MIE ((UINT)(1 << 3))
+
+#define DI(intsts)                                                             \
+  do {                                                                         \
+    UINT status = 0;                                                           \
+    asm volatile("csrrci %0, mstatus, %1"                                      \
+                 : "=r"(status)                                                \
+                 : "i"(MSTATUS_MIE)                                            \
+                 : "memory");                                                  \
+    intsts = status | ~MSTATUS_MIE;                                            \
+  } while (0)
+
+#define EI(intsts)                                                             \
+  do {                                                                         \
+    if (intsts == 0) {                                                         \
+      asm volatile("csrsi mstatus, %0" ::"i"(MSTATUS_MIE) :);                  \
+    } else {                                                                   \
+      asm volatile("csrs mstatus, %0" ::"r"(intsts & MSTATUS_MIE) :);          \
+    }                                                                          \
+  } while (0)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -1,0 +1,12 @@
+#ifndef UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
+#define UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1 */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -16,6 +16,7 @@
 
 #include <sys/profile.h>
 
+#include <sys/interrupt.h>
 #include <sys/ioport.h>
 
 #ifdef TKERNEL_CHECK_CONST

--- a/kernel/asm/rv32/start.s
+++ b/kernel/asm/rv32/start.s
@@ -16,7 +16,6 @@ _start:
   csrw mtvec, a0
 
   csrsi mie, (1<<3)
-  csrsi mstatus, (1<<3)
 
   la sp, _stack_end
 

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -40,6 +40,8 @@ void tkmc_start(int a0, int a1) {
   tcb->state = RUNNING;
   current = tcb;
 
+  EI(0);
+
   __launch_task(&tcb->sp);
 
   return;


### PR DESCRIPTION

## Description

This pull request introduces two new macros, `DI` (Disable Interrupts) and `EI` (Enable Interrupts), to provide explicit control over interrupt enablement in RISC-V systems. These macros help manage critical sections and ensure proper interrupt handling.

### Key Changes

#### 1. New Header: `sys/interrupt.h`
- Defines `DI` and `EI` macros for managing the `MSTATUS_MIE` bit in the RISC-V `mstatus` register.

```c
#define MSTATUS_MIE ((UINT)(1 << 3))

#define DI(intsts) \
  do { \
    UINT status = 0; \
    asm volatile("csrrci %0, mstatus, %1" : "=r"(status) : "i"(MSTATUS_MIE) : "memory"); \
    intsts = status | ~MSTATUS_MIE; \
  } while (0)

#define EI(intsts) \
  do { \
    if (intsts == 0) { \
      asm volatile("csrsi mstatus, %0" ::"i"(MSTATUS_MIE) :); \
    } else { \
      asm volatile("csrs mstatus, %0" ::"r"(intsts & MSTATUS_MIE) :); \
    } \
  } while (0)
```

#### 2. Integration with `tkernel.h`
- The new `sys/interrupt.h` header is included in `tkernel.h`, making the macros globally available.

```c
#include <sys/interrupt.h>
```

#### 3. Startup Code Adjustment
- The previous method of enabling interrupts (`csrsi mstatus, (1<<3)`) in `start.s` is removed.
- Instead, `EI(0)` is now explicitly called in `tkmc_start()` to enable interrupts at the appropriate point.

```c
EI(0);
```

### Benefits
- **Explicit Interrupt Control**: Provides a clear and structured way to enable or disable interrupts.
- **Improved Code Readability**: The use of `DI` and `EI` makes the intent of interrupt management more apparent.
- **Consistency with RISC-V**: Aligns with standard RISC-V practices for managing the `mstatus` register.
- **Avoids Premature Interrupt Activation**: Ensures that interrupts are only enabled after task initialization is complete.

This update provides a structured approach to interrupt management, enhancing system stability and maintainability.
