### PR TITLE
Add SPDX License Header to `interrupt.h`

### DIFF
--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -1,4 +1,10 @@
-#ifndef UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+ #ifndef UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
 #define UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
 
 #include <tk/typedef.h>


### PR DESCRIPTION

## Description

This pull request adds an SPDX license header to the `interrupt.h` file to ensure proper attribution and compliance with open-source licensing practices.

### Changes Made:
- Added the following SPDX license header to `include/sys/interrupt.h`:
  ```c
  /*
   * SPDX-FileCopyrightText: 2025 Daisuke Nagao
   *
   * SPDX-License-Identifier: MIT
   */
  ```
- Ensured consistent formatting and spacing in the file.

### Rationale:
- **License Compliance**: The addition of the SPDX identifier helps in automated license checking and compliance tracking.
- **Code Consistency**: Aligns `interrupt.h` with other kernel headers that already include the SPDX license format.
- **Attribution**: Clearly states the copyright holder and licensing terms for future reference.

This change is purely documentation-related and does not affect functionality.
