### PR TITLE
Document `intsts` Declaration Responsibility in `DI/EI` Usage

### DIFF
--- a/docs/kernel/interrupts.md
+++ b/docs/kernel/interrupts.md
@@ -1,0 +1,43 @@
+# Interrupt Status (`intsts`) Declaration in `DI/EI` Usage
+
+## Overview
+
+In uT-Kernel, the `DI()` and `EI()` macros are used to disable and enable interrupts, respectively. However, these macros require an `intsts` variable to store the previous interrupt status. The specification does not explicitly state whether the caller must declare `intsts` or if it is automatically managed by `DI()`.
+
+From the `isDI()` usage example provided in the specification, it becomes evident that `intsts` must be declared by the caller before invoking `DI()` and `EI()`. This document clarifies this requirement to avoid ambiguity and ensure correct usage.
+
+## Requirement for `intsts` Declaration
+
+The caller is responsible for declaring `intsts` before calling `DI()` or `EI()`. Failing to do so may result in undefined behavior or compilation errors.
+
+### Correct Usage Example
+
+```c
+void foo() {
+    UINT intsts; // User must declare intsts
+    DI(intsts);
+    if (isDI(intsts)) {
+        // Interrupts were already disabled
+    } else {
+        // Interrupts were enabled before DI()
+    }
+    EI(intsts);
+}
+```
+
+### Incorrect Usage Example
+
+```c
+void foo() {
+    DI(intsts); // Error: intsts is not declared
+    EI(intsts);
+}
+```
+
+## References
+
+- uT-Kernel 3.0 Specification
+- Example usage in existing uT-Kernel documentation
+
+By explicitly stating this requirement in the documentation, developers can avoid confusion and ensure proper interrupt management in their applications.
+


### PR DESCRIPTION
## Description

This pull request adds documentation clarifying the responsibility of declaring the `intsts` variable when using the `DI()` and `EI()` macros for interrupt control in uT-Kernel.

### Changes Made:
- Added a new file: `docs/kernel/interrupts.md`, which:
  - Explains that `intsts` must be explicitly declared by the caller before using `DI()` and `EI()`.
  - Provides a correct and incorrect usage example for clarity.
  - References the uT-Kernel 3.0 specification and relevant examples.

### Rationale:
- **Clarifies Usage Expectations**: The uT-Kernel specification does not explicitly state whether `intsts` is automatically managed or needs to be declared by the caller. This documentation ensures developers understand the correct approach.
- **Prevents Compilation Errors**: By making this requirement clear, developers can avoid issues related to undeclared variables when using `DI()` and `EI()`.
- **Enhances Code Consistency**: Standardizing the handling of `intsts` leads to better-maintained and more readable code across the project.

This update improves documentation quality without affecting runtime behavior.
