### PR TITLE
Refactor Task Scheduling Logic to Improve Context Switching

### DIFF
--- a/kernel/start.c
+++ b/kernel/start.c
@@ -60,9 +60,14 @@ void **schedule(void *sp) {
   TCB *tmp = current;
   tmp->sp = sp;
 
-  TCB *next = tkmc_get_highest_priority_task();
+  extern TCB *next;
+
+  if (current->state == RUNNING) {
+    current->state = READY;
+  }
+  next->state = RUNNING;
 
   current = next;
 
-  return &next->sp;
+  return &current->sp;
 }

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -85,6 +85,18 @@ ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
   return new_id;
 }
 
+TCB *tkmc_get_highest_priority_task(void) {
+
+  for (int i = 0; i < sizeof(tkmc_ready_queue) / sizeof(tkmc_ready_queue[0]);
+       ++i) {
+    if (!tkmc_list_empty(&tkmc_ready_queue[i])) {
+      return tkmc_list_first_entry(&tkmc_ready_queue[i], TCB, head);
+    }
+  }
+
+  return NULL;
+}
+
 ER tkmc_start_task(ID tskid, INT stacd) {
   if (tskid >= CFN_MAX_TSKID) {
     return E_ID;
@@ -111,18 +123,6 @@ ER tkmc_start_task(ID tskid, INT stacd) {
     }
   }
   return E_OK;
-}
-
-TCB *tkmc_get_highest_priority_task(void) {
-
-  for (int i = 0; i < sizeof(tkmc_ready_queue) / sizeof(tkmc_ready_queue[0]);
-       ++i) {
-    if (!tkmc_list_empty(&tkmc_ready_queue[i])) {
-      return tkmc_list_first_entry(&tkmc_ready_queue[i], TCB, head);
-    }
-  }
-
-  return NULL;
 }
 
 void tkmc_yield(void) {

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -9,7 +9,6 @@
 #include "task.h"
 
 extern void task1(INT stacd, void *exinf);
-extern void task2(INT stacd, void *exinf);
 
 static UW task1_stack[1024] __attribute__((aligned(16)));
 static UW task2_stack[1024] __attribute__((aligned(16)));


### PR DESCRIPTION
## Description

This pull request refactors the task scheduling logic to enhance task switching efficiency. The primary changes include refining how the next task is selected and improving the use of `next` as a global pointer for the next scheduled task.

### Key Changes:
- Introduced a global `TCB *next` variable to track the next task for execution.
- Modified `tkmc_get_highest_priority_task()` to be explicitly defined before its first use.
- Updated `schedule()` to:
  - Set the current task's state to `READY` before switching.
  - Use `next` to determine the next running task.
  - Ensure the function returns `&current->sp` instead of `&next->sp` to avoid unintended behavior.
- Updated `tkmc_start_task()` to:
  - Trigger a machine software interrupt (`out_w(0x2000000, 1)`) if the new task has higher priority than the current task.
- Refactored `tkmc_yield()` and `tkmc_ext_tsk()` to:
  - Set `next` before triggering an interrupt.
  - Remove redundant state assignments, relying on `schedule()` for updates.
- Removed the unused `task2()` declaration from `usermain.c`.

### Rationale:
- **Improves Task Selection Logic**: By maintaining a `next` pointer, task switching logic is more predictable and avoids unnecessary repeated calls to `tkmc_get_highest_priority_task()`.
- **Minimizes Unnecessary Context Switching**: Only triggers an interrupt when a new task is actually different from the current task.
- **Enhances Readability & Maintainability**: Consolidating logic reduces redundancy and potential confusion in task state transitions.

These changes refine the real-time scheduling mechanism while maintaining the overall structure of the task management system.
