### PR TITLE
 Implement Timer-based Task Scheduling and Delay Function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
           kernel/ini_tsk.c
           kernel/usermain.c
           kernel/memcpy.c
+          kernel/timer.c
           task1.c)
 
 # Set CMake compilation flags

--- a/kernel/asm/rv32/launch_task.S
+++ b/kernel/asm/rv32/launch_task.S
@@ -38,4 +38,4 @@ __launch_task:
     lw ra, 0*4(sp)
     lw a3, 28*4(sp)
     addi  sp, sp, 4*32
-    jalr x0, a3, 0
+    jr a3

--- a/kernel/asm/rv32/start.S
+++ b/kernel/asm/rv32/start.S
@@ -139,19 +139,9 @@ timer_interrupt:
   sw t5, 26*4(sp)
   sw t6, 27*4(sp)
 
-  /* Clear timer interrupt by updating mtimecmp */
-  li a0, 0x2004000       /* mtimecmp address */
-  li a1, 0x200BFF8       /* mtime address */
-  lw a2, 0(a1)           /* Read current time */
-  li t0, 100000         /* Load immediate value */
-  add a2, a2, t0         /* Schedule next interrupt */
-  sw a2, 0(a0)           /* Write to mtimecmp */
+  call tkmc_timer_handler
 
-  li a0, 0x10000000
-  li a1, 0x23
-  sw a1, 0(a0)
   /* Return from interrupt */
-
   lw t6, 27*4(sp)
   lw t5, 26*4(sp)
   lw t4, 25*4(sp)

--- a/kernel/asm/rv32/start.S
+++ b/kernel/asm/rv32/start.S
@@ -20,14 +20,6 @@ _start:
   li t0, (1<<3) | (1<<7)
   csrs mie, t0
 
-  /* Set mtimecmp = mtime + initial value */
-  li a0, CLINT_BASE_ADDRESS + CLINT_MTIMECMP_OFFSET /* mtimecmp address */
-  li a1, CLINT_BASE_ADDRESS + CLINT_MTIME_OFFSET    /* mtime address */
-  lw a2, 0(a1)                                      /* Read mtime */
-  li t0, 100000                                     /* Load immediate value into a temporary register */
-  add a2, a2, t0                                    /* Add the value */
-  sw a2, 0(a0)                                      /* Write to mtimecmp */
-
   la sp, _stack_end
 
   call tkmc_start

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -53,6 +53,25 @@ static inline void tkmc_list_add_tail(tkmc_list_head *new,
   head->prev = new;
 }
 
+/* Macro to get the next element */
+#define tkmc_list_next_entry(pos, member)                                      \
+  tkmc_list_entry((pos)->member.next, typeof(*(pos)), member)
+
+/* Macro for normal traversal */
+#define tkmc_list_for_each_entry(pos, head, member)                            \
+  for (pos = tkmc_list_first_entry(head, typeof(*pos), member);                \
+       &pos->member != (head); pos = tkmc_list_next_entry(pos, member))
+
+/*
+ * Macro for safe traversal:
+ * Since the next element `n` is pre-fetched even if `pos` is deleted within
+ * the loop, the entire list can be safely traversed.
+ */
+#define tkmc_list_for_each_entry_safe(pos, n, head, member)                    \
+  for (pos = tkmc_list_first_entry(head, typeof(*pos), member),                \
+      n = tkmc_list_next_entry(pos, member);                                   \
+       &pos->member != (head); pos = n, n = tkmc_list_next_entry(n, member))
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -40,6 +40,8 @@ void tkmc_start(int a0, int a1) {
   tcb->state = RUNNING;
   current = tcb;
 
+  extern void tkmc_start_timer(void);
+  tkmc_start_timer();
   EI(0);
 
   __launch_task(&tcb->sp);

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -35,6 +35,7 @@ enum TaskState {
   DORMANT,
   READY,
   RUNNING,
+  WAIT,
 };
 
 /* Task Control Block */
@@ -46,6 +47,7 @@ typedef struct TCB {
   void *sp;
   FP task;
   void *exinf;
+  UINT tick_count;
 } TCB;
 
 extern TCB *current;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -1,0 +1,83 @@
+// clang-format off
+#include "timer.h"
+#include <tk/tkernel.h>
+// clang-format on
+#include "../putstring.h"
+#include "asm/rv32/address.h"
+#include "list.h"
+#include "task.h"
+
+tkmc_list_head tkmc_timer_queue;
+
+#define CLINT_MSIP_ADDRESS (CLINT_BASE_ADDRESS + CLINT_MSIP_OFFSET)
+#define CLINT_MTIME_ADDRESS (CLINT_BASE_ADDRESS + CLINT_MTIME_OFFSET)
+#define CLINT_MTIMECMP_ADDRESS (CLINT_BASE_ADDRESS + CLINT_MTIMECMP_OFFSET)
+extern tkmc_list_head tkmc_ready_queue[CFN_MAX_PRI];
+
+static UW s_mtimecmp;
+void tkmc_start_timer(void) {
+  tkmc_init_list_head(&tkmc_timer_queue);
+  s_mtimecmp = *(_UW *)(CLINT_MTIME_ADDRESS);
+  s_mtimecmp += 100000;
+  *(_UW *)(CLINT_MTIMECMP_ADDRESS) = s_mtimecmp;
+}
+
+void tkmc_timer_handler(void) {
+  UW mtime = *(_UW *)(CLINT_MTIME_ADDRESS);
+  UW mtimecmp = s_mtimecmp;
+  while (mtime >= mtimecmp) {
+    mtimecmp += 100000;
+    mtime = *(_UW *)(CLINT_MTIME_ADDRESS);
+  }
+  *(_UW *)(CLINT_MTIMECMP_ADDRESS) = mtimecmp;
+  s_mtimecmp = mtimecmp;
+
+  if (!tkmc_list_empty(&tkmc_timer_queue)) {
+    TCB *tcb, *n;
+    tkmc_list_for_each_entry_safe(tcb, n, &tkmc_timer_queue, head) {
+      tcb->tick_count -= 1;
+      if (tcb->tick_count == 0) {
+        tkmc_list_del(&tcb->head);
+        tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[tcb->itskpri - 1]);
+        tcb->state = READY;
+        extern TCB *next;
+        TCB *tkmc_get_highest_priority_task(void);
+        next = tkmc_get_highest_priority_task();
+        if (next != current) {
+          out_w(CLINT_MSIP_ADDRESS, 1);
+        }
+      }
+    }
+  }
+}
+
+void memset(void *ptr, int c, typeof(sizeof(int)) sz) {}
+
+void tkmc_move_to_timer_queue(TCB *tcb, UINT tick_count) {
+  UINT intsts;
+  DI(intsts);
+  tcb->state = WAIT;
+  tcb->tick_count = tick_count;
+  tkmc_list_del(&tcb->head);
+  tkmc_list_add_tail(&tcb->head, &tkmc_timer_queue);
+  extern TCB *next;
+  TCB *tkmc_get_highest_priority_task(void);
+  next = tkmc_get_highest_priority_task();
+  out_w(CLINT_MSIP_ADDRESS, 1);
+  EI(intsts);
+}
+
+ER tkmc_dly_tsk(TMO tmout) {
+  if (tmout == 0) {
+    extern void tkmc_yield();
+    tkmc_yield();
+    return E_OK;
+  }
+  ID tskid = current->tskid;
+  extern TCB tkmc_tcbs[CFN_MAX_TSKID];
+
+  TCB *tcb = &tkmc_tcbs[tskid - 1];
+
+  tkmc_move_to_timer_queue(tcb, ((tmout + 9) / 10));
+  return E_OK;
+}

--- a/kernel/timer.h
+++ b/kernel/timer.h
@@ -1,0 +1,12 @@
+#ifndef UUID_01955F79_CF88_76A9_B43B_7899A0391E87
+#define UUID_01955F79_CF88_76A9_B43B_7899A0391E87
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* UUID_01955F79_CF88_76A9_B43B_7899A0391E87 */

--- a/task1.c
+++ b/task1.c
@@ -20,6 +20,11 @@ void task1(INT stacd, void *exinf) {
     } else {
       putstring(" 2\n");
     }
-    tkmc_yield();
+    extern ER tkmc_dly_tsk(TMO tmout);
+    if (msg[0] == 'H') {
+      tkmc_dly_tsk(10);
+    } else {
+      tkmc_dly_tsk(0);
+    }
   }
 }


### PR DESCRIPTION
## Description

This pull request introduces a timer-based task scheduling mechanism and a delay function (`tkmc_dly_tsk`) for better task synchronization and time management.

### Key Changes:

#### **Timer Implementation**
- **Added `kernel/timer.c` and `kernel/timer.h`** to handle periodic timer interrupts.
- **Modified `start.S`**:
  - Removed direct manipulation of `mtimecmp` in assembly.
  - Delegated timer interrupt handling to `tkmc_timer_handler()` in C.
- **Refactored `task.c`**:
  - Tasks now transition to a waiting state (`WAIT`) when delayed.
  - Introduced `tkmc_move_to_timer_queue()` to enqueue tasks into a timer queue.
- **Interrupt Handling Improvements**:
  - Ensured atomic operations using `DI()` and `EI()` around scheduling-critical sections.

#### **Task Delay Mechanism**
- **Implemented `tkmc_dly_tsk(TMO tmout)`**:
  - If `tmout == 0`, the task yields immediately.
  - Otherwise, the task is moved to the timer queue and resumes execution after `tmout` ticks.

#### **Task Management Enhancements**
- **Refactored Task Switching**:
  - Introduced `next` as a global pointer for the next scheduled task.
  - Tasks now transition explicitly from `READY` to `WAIT` states.
- **Introduced List Macros in `list.h`**:
  - Added `tkmc_list_for_each_entry` and `tkmc_list_for_each_entry_safe` for cleaner list traversal.

#### **Code Quality & Miscellaneous Fixes**
- **Renamed Assembly Files** (`.s` → `.S`) to enable preprocessing.
- **Updated `CMakeLists.txt`**:
  - Added `kernel/timer.c` to the build.
  - Ensured proper case-sensitive handling of renamed assembly files.
- **Modified `task1.c` to use `tkmc_dly_tsk()`** instead of `tkmc_yield()` for controlled task execution.

### Rationale:
- **Supports Precise Task Scheduling**: The kernel now uses timer interrupts to drive periodic task execution.
- **Ensures Proper Preemptive Scheduling**: Tasks can delay execution without manually yielding.
- **Enhances Readability and Maintainability**: Isolating timer logic in `timer.c` keeps the scheduler cleaner.

This PR establishes a foundation for time-driven operations, improving task responsiveness and execution control.
