### PR TITLE
Align Task Management API with uT-Kernel Naming Conventions

### DIFF
--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -49,9 +49,9 @@ typedef struct T_CTSK {
   void *bufptr; /* Buffer Pointer */
 } T_CTSK;
 
-extern void tkmc_ext_tsk(void);
-extern ID tkmc_create_task(const T_CTSK *pk_ctsk);
-extern ER tkmc_start_task(ID tskid, INT stacd);
+extern void tk_ext_tsk(void);
+extern ID tk_cre_tsk(const T_CTSK *pk_ctsk);
+extern ER tk_sta_tsk(ID tskid, INT stacd);
 extern ER tk_dly_tsk(TMO tmout);
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/kernel/ini_tsk.c
+++ b/kernel/ini_tsk.c
@@ -10,5 +10,5 @@ extern void usermain(int _a0);
 
 void tkmc_ini_tsk(INT stacd, void *exinf) {
   usermain(stacd);
-  tkmc_ext_tsk();
+  tk_ext_tsk();
 }

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -28,8 +28,8 @@ void tkmc_start(int a0, int a1) {
       .bufptr = ini_tsk_stack,
   };
 
-  ID ini_tsk_id = tkmc_create_task(&pk_ctsk);
-  tkmc_start_task(ini_tsk_id, a0);
+  ID ini_tsk_id = tk_cre_tsk(&pk_ctsk);
+  tk_sta_tsk(ini_tsk_id, a0);
 
   TCB *tcb = tkmc_get_highest_priority_task();
   tcb->state = RUNNING;

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -39,7 +39,7 @@ void tkmc_init_tcb(void) {
   }
 }
 
-ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
+ID tk_cre_tsk(CONST T_CTSK *pk_ctsk) {
   const ATR tskatr = pk_ctsk->tskatr;
   static const ATR VALID_TSKATR =
       TA_ASM | TA_HLNG | TA_USERBUF | TA_RNG0 | TA_RNG1 | TA_RNG2 | TA_RNG3;
@@ -73,7 +73,7 @@ ID tkmc_create_task(CONST T_CTSK *pk_ctsk) {
     for (int i = 0; i < 32; ++i) {
       stack_end[i] = 0xdeadbeef;
     }
-    stack_end[0] = (UW)tkmc_ext_tsk;   /* ra */
+    stack_end[0] = (UW)tk_ext_tsk;   /* ra */
     stack_end[28] = (UW)pk_ctsk->task; /* mepc */
     new_tcb->sp = stack_end;
     new_tcb->task = pk_ctsk->task;
@@ -99,7 +99,7 @@ TCB *tkmc_get_highest_priority_task(void) {
   return NULL;
 }
 
-ER tkmc_start_task(ID tskid, INT stacd) {
+ER tk_sta_tsk(ID tskid, INT stacd) {
   if (tskid >= CFN_MAX_TSKID) {
     return E_ID;
   }
@@ -145,7 +145,7 @@ void tkmc_yield(void) {
   EI(intsts);
 }
 
-void tkmc_ext_tsk(void) {
+void tk_ext_tsk(void) {
   TCB *tmp = current;
   UINT intsts = 0;
   DI(intsts);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -1,8 +1,7 @@
 // clang-format off
-#include "timer.h"
 #include <tk/tkernel.h>
 // clang-format on
-#include "../putstring.h"
+#include "timer.h"
 #include "asm/rv32/address.h"
 #include "list.h"
 #include "task.h"
@@ -66,7 +65,7 @@ void tkmc_move_to_timer_queue(TCB *tcb, UINT tick_count) {
   EI(intsts);
 }
 
-ER tkmc_dly_tsk(TMO tmout) {
+ER tk_dly_tsk(TMO tmout) {
   if (tmout == 0) {
     tkmc_yield();
     return E_OK;

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -34,9 +34,9 @@ void usermain(int _a0) {
       .stksz = sizeof(task2_stack),
       .bufptr = task2_stack,
   };
-  ID task1_id = tkmc_create_task(&pk_ctsk1);
-  ID task2_id = tkmc_create_task(&pk_ctsk2);
+  ID task1_id = tk_cre_tsk(&pk_ctsk1);
+  ID task2_id = tk_cre_tsk(&pk_ctsk2);
 
-  tkmc_start_task(task1_id, 1);
-  tkmc_start_task(task2_id, 2);
+  tk_sta_tsk(task1_id, 1);
+  tk_sta_tsk(task2_id, 2);
 }

--- a/task1.c
+++ b/task1.c
@@ -18,11 +18,10 @@ void task1(INT stacd, void *exinf) {
     } else {
       putstring(" 2\n");
     }
-    extern ER tkmc_dly_tsk(TMO tmout);
     if (msg[0] == 'H') {
-      tkmc_dly_tsk(10);
+      tk_dly_tsk(10);
     } else {
-      tkmc_dly_tsk(0);
+      tk_dly_tsk(0);
     }
   }
 }


### PR DESCRIPTION
Align Task Management API with uT-Kernel Naming Conventions

## Description

This pull request updates task management function names to align with **uT-Kernel 3.0 naming conventions**, replacing `tkmc_*` prefixes with `tk_*`. This change enhances code clarity and maintains consistency with the standard API.

### Key Changes:

#### **Task Management Function Renaming**
- `tkmc_create_task` → **`tk_cre_tsk`**
- `tkmc_start_task` → **`tk_sta_tsk`**
- `tkmc_ext_tsk` → **`tk_ext_tsk`**
- `tkmc_dly_tsk` → **`tk_dly_tsk`**

#### **Codebase-Wide Function Usage Update**
- All occurrences of the old function names in:
  - `start.c`
  - `usermain.c`
  - `task.c`
  - `timer.c`
  - `ini_tsk.c`
  - `task1.c`
  - Other relevant files
- Updated comments and stack initialization to reflect the new function names.

#### **Header Adjustments**
- `tkernel.h` now declares `tk_*` functions instead of `tkmc_*`.
- Removed redundant `extern` function declarations from `.c` files.

### Rationale:
- **Consistency with uT-Kernel Specification**: Using standard function names ensures easier adoption and comparison with uT-Kernel implementations.
- **Improved Code Readability**: Standardized function names make the API intuitive.
- **Future Maintainability**: Aligning function names with the expected kernel conventions reduces confusion for new contributors.

This change makes the API more consistent with the uT-Kernel specification while preserving all existing functionalities.
