### PR TITLE
Introduce Idle Task and Improve Task Initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
   ${EXECUTABLE}
   PRIVATE kernel/asm/rv32/start.S
           kernel/asm/rv32/launch_task.S
+          kernel/asm/rv32/idl_tsk.S
           kernel/start.c
           kernel/task.c
           kernel/ini_tsk.c

--- a/kernel/asm/rv32/idl_tsk.S
+++ b/kernel/asm/rv32/idl_tsk.S
@@ -4,3 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
   .text
+  .global tkmc_idl_tsk, @function
+  .balign 4
+tkmc_idl_tsk:
+1:
+  li a0, 0
+  call tk_dly_tsk
+  j 1b

--- a/kernel/asm/rv32/idl_tsk.S
+++ b/kernel/asm/rv32/idl_tsk.S
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+  .text

--- a/task1.c
+++ b/task1.c
@@ -21,7 +21,7 @@ void task1(INT stacd, void *exinf) {
     if (msg[0] == 'H') {
       tk_dly_tsk(10);
     } else {
-      tk_dly_tsk(0);
+      tk_dly_tsk(30);
     }
   }
 }


### PR DESCRIPTION
## Description

This update introduces a **dedicated idle task (`tkmc_idl_tsk`)** to ensure that the system always has at least one runnable task. It also **improves task initialization** by structuring task creation logic for better readability and maintainability.

### Key Changes:

#### **1. Introduce Idle Task (`tkmc_idl_tsk`)**
- Added a new **idle task (`idl_tsk.S`)** that continuously calls `tk_dly_tsk(0)`.
- This prevents the system from entering an undefined state when no other tasks are ready.
- The idle task runs at the **lowest priority** (`CFN_MAX_PRI`).

#### **2. Refactor Initial Task Creation (`start.c`)**
- The initialization of `tkmc_ini_tsk` and `tkmc_idl_tsk` is now **clearly separated**.
- Improves readability by encapsulating each task creation into its own scope.

#### **3. Modify Task Timing (`task1.c`)**
- Increased the delay in `task1.c` from **0 to 30ms** to allow better task scheduling.
- Ensures that the idle task has opportunities to run when other tasks are waiting.

### Rationale:
- **Prevents Undefined States**: Ensures that the system always has at least one runnable task.
- **Improves Readability**: The new structure makes the task initialization process clearer.
- **Better Scheduling Behavior**: The increased delay allows the system to better handle idle periods.

This update aligns with **best practices for RTOS development** and enhances system stability.
