### PR TITLE
Implement isDI function

### DIFF
--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
- #ifndef UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
+#ifndef UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
 #define UUID_019542DF_8F10_70F0_AE6B_848A71C04DB1
 
 #include <tk/typedef.h>
@@ -33,6 +33,10 @@ extern "C" {
       asm volatile("csrs mstatus, %0" ::"r"(intsts & MSTATUS_MIE) :);          \
     }                                                                          \
   } while (0)
+
+static inline BOOL isDI(UINT intsts) {
+  return (intsts & MSTATUS_MIE) == 0 ? TRUE : FALSE;
+}
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
- Added `isDI` function in `interrupt.h` to check if interrupts are disabled.
- `isDI` returns `TRUE` if `MSTATUS_MIE` is cleared in `intsts`, otherwise `FALSE`.