### PR TITLE
Reset stack pointer when restarting a task

### DIFF
--- a/kernel/task.h
+++ b/kernel/task.h
@@ -30,6 +30,7 @@ typedef struct TCB {
   PRI itskpri;
   enum TaskState state;
   void *sp;
+  void *initial_sp;
   FP task;
   void *exinf;
   UINT tick_count;


### PR DESCRIPTION
- Added `initial_sp` field to `TCB` to store the initial stack pointer.
- Modified `tk_cre_tsk` to set `initial_sp` at task creation.
- Updated `tk_sta_tsk` to reset the stack pointer to `initial_sp` before execution.
- Ensured that tasks start with a clean stack on each execution.