### PR TITLE
[Refactor] Separate Initialization from Start in Timer Module

### DIFF
--- a/kernel/start.c
+++ b/kernel/start.c
@@ -40,6 +40,7 @@ void tkmc_start(int a0, int a1) {
 
   /* Initialize the Task Control Block (TCB) system. */
   tkmc_init_tcb();
+  tkmc_init_timer();
 
   /* create tkmc_ini_tsk */
   {

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -17,13 +17,15 @@ tkmc_list_head tkmc_timer_queue;
 /* Static variable to store the next timer compare value */
 static UW s_mtimecmp;
 
+void tkmc_init_timer(void) { tkmc_init_list_head(&tkmc_timer_queue); }
+
 /*
  * Initialize the timer system.
  * - Sets up the timer queue.
  * - Configures the initial timer compare value.
  */
 void tkmc_start_timer(void) {
-  tkmc_init_list_head(&tkmc_timer_queue);
+  // tkmc_init_list_head(&tkmc_timer_queue);
   s_mtimecmp = *(_UW *)(CLINT_MTIME_ADDRESS);
   s_mtimecmp += 100000; // Set the initial timer compare value
   *(_UW *)(CLINT_MTIMECMP_ADDRESS) = s_mtimecmp;

--- a/kernel/timer.h
+++ b/kernel/timer.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 extern void tkmc_start_timer(void);
+extern void tkmc_init_timer(void);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
- Added `tkmc_init_timer` to handle timer queue initialization separately.
- Moved timer queue initialization from `tkmc_start_timer` to `tkmc_init_timer`.
- Updated `tkmc_start` to call `tkmc_init_timer` before task initialization.
- Ensured a clear separation between setup and activation of the timer system.