### PR TITLE
[Refactor] Add Memory Barrier to out_w and Related Functions

### DIFF
--- a/include/sys/ioport.h
+++ b/include/sys/ioport.h
@@ -9,13 +9,24 @@
 
 #include <tk/typedef.h>
 
+#define tkmc_compiler_barrier() asm volatile("" ::: "memory")
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-static inline void out_b(INT port, UB data) { *(_UB *)port = data; }
-static inline void out_h(INT port, UH data) { *(_UH *)port = data; }
-static inline void out_w(INT port, UW data) { *(_UW *)port = data; }
+static inline void out_b(INT port, UB data) {
+  tkmc_compiler_barrier();
+  *(_UB *)port = data;
+}
+static inline void out_h(INT port, UH data) {
+  tkmc_compiler_barrier();
+  *(_UH *)port = data;
+}
+static inline void out_w(INT port, UW data) {
+  tkmc_compiler_barrier();
+  *(_UW *)port = data;
+}
 
 static inline UB in_b(INT port) { return *(_UB *)port; }
 static inline UH in_h(INT port) { return *(_UH *)port; }


### PR DESCRIPTION
- Introduced `tkmc_compiler_barrier()` to enforce memory ordering before I/O operations.
- Updated `out_b`, `out_h`, and `out_w` functions to include a compiler barrier before writing to memory-mapped I/O.
- Ensured correctness in memory-mapped register writes to prevent unintended reordering by the compiler.