### PR TITLE
Implement Task Release Mechanism (`tk_rel_wai()`)

### DIFF
--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -53,5 +53,6 @@ extern void tk_ext_tsk(void);
 extern ID tk_cre_tsk(const T_CTSK *pk_ctsk);
 extern ER tk_sta_tsk(ID tskid, INT stacd);
 extern ER tk_dly_tsk(TMO tmout);
+extern ER tk_rel_wai(ID tskid);
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -251,14 +251,6 @@ void tk_ext_tsk(void) {
 }
 
 ER tk_rel_wai(ID tskid) {
-  /*
-  E_OK 正常終了
-  E_ID 不正ID番号(tskid が不正あるいは利用できない)
-  E_NOEXS オブジェクトが存在していない(tskidのタスクが存在しない)
-  E_OBJ
-  利用可能なコンテキストオブジェクトの状態が不正(対象タスクが待ち状態ではない(自タスクや休止状態(DORMANT)の場合を含む))
-  */
-
   ER ercd = E_OK;
 
   if (tskid > CFN_MAX_TSKID) {

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -166,7 +166,7 @@ TCB *tkmc_get_highest_priority_task(void) {
  * - E_OK on success, or an error code if the task cannot be started.
  */
 ER tk_sta_tsk(ID tskid, INT stacd) {
-  if (tskid >= CFN_MAX_TSKID) {
+  if (tskid > CFN_MAX_TSKID) {
     return E_ID; // Invalid task ID
   }
   TCB *tcb = tkmc_tcbs + tskid - 1;
@@ -283,7 +283,6 @@ ER tk_rel_wai(ID tskid) {
     if (current != next) {
       out_w(CLINT_MSIP_ADDRESS, 1);
     }
-    __sync_synchronize();
   }
   EI(intsts);
   return ercd;

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -250,6 +250,22 @@ void tk_ext_tsk(void) {
   EI(intsts);
 }
 
+/*
+ * Release a waiting task.
+ * - Moves the specified task from the WAIT state to the READY state.
+ * - Removes the task from the waiting queue and adds it to the appropriate
+ * ready queue.
+ * - Triggers a context switch if a higher-priority task is ready.
+ *
+ * Parameters:
+ * - tskid: Task ID of the task to be released.
+ *
+ * Returns:
+ * - E_OK on success.
+ * - E_ID if the task ID is invalid.
+ * - E_NOEXS if the task does not exist.
+ * - E_OBJ if the task is not in the WAIT state.
+ */
 ER tk_rel_wai(ID tskid) {
   ER ercd = E_OK;
 

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -37,6 +37,6 @@ void usermain(int _a0) {
   ID task1_id = tk_cre_tsk(&pk_ctsk1);
   ID task2_id = tk_cre_tsk(&pk_ctsk2);
 
-  tk_sta_tsk(task1_id, 1);
-  tk_sta_tsk(task2_id, 2);
+  tk_sta_tsk(task1_id, task1_id);
+  tk_sta_tsk(task2_id, task2_id);
 }

--- a/task1.c
+++ b/task1.c
@@ -13,7 +13,8 @@ void task1(INT stacd, void *exinf) {
   const char *msg = (const char *)exinf;
   while (1) {
     putstring(msg);
-    if (stacd == 1) {
+    if (stacd == 3) {
+      tk_rel_wai(4);
       putstring(" 1\n");
     } else {
       putstring(" 2\n");


### PR DESCRIPTION
## Description

This update introduces a **task release mechanism (`tk_rel_wai()`)**,  
allowing tasks in the **WAIT** state to be **manually resumed**.

### **Key Enhancements:**

#### **1. `tk_rel_wai()` API Implementation**
- **Unblocks a waiting task** and moves it to the **READY** queue.
- **Triggers a context switch** if the released task has a higher priority.
- Returns:
  - `E_OK` → Task successfully released
  - `E_ID` → Invalid task ID
  - `E_NOEXS` → Task does not exist
  - `E_OBJ` → Task is not in the WAIT state

#### **2. Task Control Updates**
- **Revised task IDs in `usermain.c`** to ensure correct task management.
- **Modified `task1.c` to demonstrate task wake-up behavior**:
  - Task **3** now releases **Task 4** when executed.

### **Rationale:**
- **Essential for Inter-Task Synchronization**:  
  - Tasks waiting on a signal/event can now be explicitly resumed.
- **Aligns with uT-Kernel's Event Mechanisms**:  
  - Future extensions (e.g., **semaphores**, **message queues**) will use the same logic.
- **Improves Real-Time Task Scheduling**:  
  - Prevents unnecessary delays by allowing immediate resumption.

This update **enables flexible task wake-up control**, making it easier to build  
**efficient real-time systems** with precise synchronization.
