### PR TITLE
Update Task State Definitions for Consistency with uT-Kernel

### DIFF
--- a/kernel/start.c
+++ b/kernel/start.c
@@ -83,7 +83,7 @@ void tkmc_start(int a0, int a1) {
 
   /* Retrieve the highest-priority task (should be the initial task). */
   TCB *tcb = tkmc_get_highest_priority_task();
-  tcb->state = RUNNING; // Mark the task as running
+  tcb->state = TTS_RUN; // Mark the task as running
   current = tcb;        // Set the current task pointer
 
   /* Start the system timer for task scheduling. */
@@ -126,10 +126,10 @@ void **schedule(void *sp) {
   tmp->sp = sp;
 
   /* Update the state of the current task. */
-  if (current->state == RUNNING) {
-    current->state = READY; // Move the current task back to the READY state
+  if (current->state == TTS_RUN) {
+    current->state = TTS_RDY; // Move the current task back to the TTS_RDY state
   }
-  next->state = RUNNING; // Mark the next task as running
+  next->state = TTS_RUN; // Mark the next task as running
 
   /* Update the current task pointer to the next task. */
   current = next;

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -16,11 +16,11 @@ extern "C" {
 #endif /* __cplusplus */
 
 enum TaskState {
-  TTS_NOEXS = 0,
-  TTS_DMT,
-  TTS_RDY,
-  TTS_RUN,
-  TTS_WAI,
+  TTS_NOEXS = 0x0000,
+  TTS_RUN = 0x0001,
+  TTS_RDY = 0x0002,
+  TTS_WAI = 0x0004,
+  TTS_DMT = 0x0010,
 };
 
 /* Task Control Block */

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -20,7 +20,10 @@ enum TaskState {
   TTS_RUN = 0x0001,
   TTS_RDY = 0x0002,
   TTS_WAI = 0x0004,
+  TTS_SUS = 0x0008,
+  TTS_WAS = 0x000c,
   TTS_DMT = 0x0010,
+  TTS_NODISWAI = 0x0080,
 };
 
 /* Task Control Block */

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -16,11 +16,11 @@ extern "C" {
 #endif /* __cplusplus */
 
 enum TaskState {
-  NON_EXISTENT = 0,
-  DORMANT,
-  READY,
-  RUNNING,
-  WAIT,
+  TTS_NOEXS = 0,
+  TTS_DMT,
+  TTS_RDY,
+  TTS_RUN,
+  TTS_WAI,
 };
 
 /* Task Control Block */

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -57,7 +57,7 @@ void tkmc_timer_handler(void) {
         /* Move the task to the ready queue */
         tkmc_list_del(&tcb->head);
         tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[tcb->itskpri - 1]);
-        tcb->state = READY;
+        tcb->state = TTS_RDY;
         tcb->wupcause = E_TMOUT;
 
         /* Update the next task to be scheduled */
@@ -72,7 +72,7 @@ void tkmc_timer_handler(void) {
 
 /*
  * Move a task to the timer queue.
- * - Sets the task's state to WAIT.
+ * - Sets the task's state to TTS_WAI.
  * - Adds the task to the timer queue with the specified tick count.
  *
  * Parameters:
@@ -83,7 +83,7 @@ void tkmc_timer_handler(void) {
 static ER schedule_timer(TCB *tcb, UINT delay_ticks) {
   UINT intsts;
   DI(intsts);
-  tcb->state = WAIT;
+  tcb->state = TTS_WAI;
   tcb->delay_ticks = delay_ticks;
   tkmc_list_del(&tcb->head);
   tkmc_list_add_tail(&tcb->head, &tkmc_timer_queue);


### PR DESCRIPTION
## Description

This update refactors **task state definitions** to align with the **uT-Kernel 3.0** specifications.  
State names are now prefixed with **`TTS_`**, and task management functions have been updated accordingly.

### **Key Changes:**

#### **1. Task State Enumeration (`TaskState`)**
- **Updated states** to match the uT-Kernel naming convention:
  - `NON_EXISTENT` → `TTS_NOEXS`
  - `RUNNING` → `TTS_RUN`
  - `READY` → `TTS_RDY`
  - `WAIT` → `TTS_WAI`
  - `DORMANT` → `TTS_DMT`
  - **Added new states for future extensions**:
    - `TTS_SUS` (Suspended)
    - `TTS_WAS` (Wait + Suspended)
    - `TTS_NODISWAI` (Non-Disabling Wait)

#### **2. Task State Handling in Core Functions**
- **Updated all state transitions** to use `TTS_`-prefixed states.

### **Rationale:**
- **Ensures compatibility with future uT-Kernel API extensions.**
- **Improves maintainability** by using standard state definitions.
- **Prepares the kernel for advanced task synchronization mechanisms**  
  (e.g., suspensions, forced wakeups, and preemptive scheduling).
