### PR TITLE
Introduce `tskstat` and `tskwait` for Precise Task State Management

### DIFF
--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -28,9 +28,9 @@ extern "C" {
 #define EI(intsts)                                                             \
   do {                                                                         \
     if (intsts == 0) {                                                         \
-      asm volatile("csrsi mstatus, %0" ::"i"(MSTATUS_MIE) :);                  \
+      asm volatile("csrsi mstatus, %0" ::"i"(MSTATUS_MIE) : "memory");         \
     } else {                                                                   \
-      asm volatile("csrs mstatus, %0" ::"r"(intsts & MSTATUS_MIE) :);          \
+      asm volatile("csrs mstatus, %0" ::"r"(intsts & MSTATUS_MIE) : "memory"); \
     }                                                                          \
   } while (0)
 

--- a/include/sys/ioport.h
+++ b/include/sys/ioport.h
@@ -9,24 +9,13 @@
 
 #include <tk/typedef.h>
 
-#define tkmc_compiler_barrier() asm volatile("" ::: "memory")
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-static inline void out_b(INT port, UB data) {
-  tkmc_compiler_barrier();
-  *(_UB *)port = data;
-}
-static inline void out_h(INT port, UH data) {
-  tkmc_compiler_barrier();
-  *(_UH *)port = data;
-}
-static inline void out_w(INT port, UW data) {
-  tkmc_compiler_barrier();
-  *(_UW *)port = data;
-}
+static inline void out_b(INT port, UB data) { *(_UB *)port = data; }
+static inline void out_h(INT port, UH data) { *(_UH *)port = data; }
+static inline void out_w(INT port, UW data) { *(_UW *)port = data; }
 
 static inline UB in_b(INT port) { return *(_UB *)port; }
 static inline UH in_h(INT port) { return *(_UH *)port; }

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -52,7 +52,8 @@ typedef struct T_CTSK {
 extern void tk_ext_tsk(void);
 extern ID tk_cre_tsk(const T_CTSK *pk_ctsk);
 extern ER tk_sta_tsk(ID tskid, INT stacd);
-extern ER tk_dly_tsk(TMO tmout);
+extern ER tk_dly_tsk(TMO dlytm);
+// extern ER tk_slp_tsk(TMO tmout);
 extern ER tk_rel_wai(ID tskid);
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -53,7 +53,7 @@ extern void tk_ext_tsk(void);
 extern ID tk_cre_tsk(const T_CTSK *pk_ctsk);
 extern ER tk_sta_tsk(ID tskid, INT stacd);
 extern ER tk_dly_tsk(TMO dlytm);
-// extern ER tk_slp_tsk(TMO tmout);
+extern ER tk_slp_tsk(TMO tmout);
 extern ER tk_rel_wai(ID tskid);
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/kernel/dispatch.h
+++ b/kernel/dispatch.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UUID_0195A180_E38C_74B5_9314_CA66B708899A
+#define UUID_0195A180_E38C_74B5_9314_CA66B708899A
+
+#include "asm/rv32/address.h"
+#include <tk/tkernel.h>
+
+#define tkmc_compiler_barrier() asm volatile("" ::: "memory")
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+static inline void dispatch(void) {
+  tkmc_compiler_barrier();
+  // Trigger a machine software interrupt
+  out_w((CLINT_BASE_ADDRESS + CLINT_MSIP_OFFSET), 1);
+  tkmc_compiler_barrier();
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* UUID_0195A180_E38C_74B5_9314_CA66B708899A */

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -51,6 +51,7 @@ void tkmc_init_tcb(void) {
         .exinf = NULL, // Extended information (user-defined data for the task)
         .delay_ticks = 0, // Reset countdown timer for sleep/delay
         .wupcause = E_OK, // Wakeup cause (default to normal wakeup)
+        .wupcnt = 0,
     };
     tkmc_init_list_head(&tcb->head);
 
@@ -129,6 +130,7 @@ ID tk_cre_tsk(CONST T_CTSK *pk_ctsk) {
     new_tcb->exinf = pk_ctsk->exinf; // Store user-defined extended information
     new_tcb->delay_ticks = 0; // Initialize delay timer (task is not delayed)
     new_tcb->wupcause = E_OK; // Default wakeup cause
+    new_tcb->wupcnt = 0;
   } else {
     new_id = (ID)E_LIMIT; // Task creation failed
   }
@@ -295,6 +297,7 @@ ER tk_rel_wai(ID tskid) {
     tcb->tskstat = TTS_RDY;
     tcb->tskwait = 0;
     tcb->wupcause = E_RLWAI;
+    tcb->wupcnt = 0;
     tkmc_list_del(&tcb->head);
     tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[tcb->itskpri - 1]);
 

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -299,7 +299,9 @@ ER tk_rel_wai(ID tskid) {
     tcb->tskwait = 0;
     tcb->wupcause = E_RLWAI;
     tcb->wupcnt = 0;
-    tkmc_list_del(&tcb->head);
+    if (!tkmc_list_empty(&tcb->head)) {
+      tkmc_list_del(&tcb->head);
+    }
     tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[tcb->itskpri - 1]);
 
     next = tkmc_get_highest_priority_task();

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -6,6 +6,7 @@
 
 #include "task.h"
 #include "asm/rv32/address.h"
+#include "dispatch.h"
 
 /* Memory-mapped addresses for the CLINT (Core Local Interruptor) */
 #define CLINT_MSIP_ADDRESS (CLINT_BASE_ADDRESS + CLINT_MSIP_OFFSET)
@@ -207,7 +208,7 @@ ER tk_sta_tsk(ID tskid, INT stacd) {
   if (current != NULL) {
     next = tkmc_get_highest_priority_task();
     if (next != current) {
-      out_w(CLINT_MSIP_ADDRESS, 1); // Trigger a machine software interrupt
+      dispatch();
     }
   }
   EI(intsts);
@@ -232,7 +233,7 @@ void tkmc_yield(void) {
   /* Update the next task to be scheduled */
   next = tkmc_get_highest_priority_task();
   if (tmp != next) {
-    out_w(CLINT_MSIP_ADDRESS, 1); // Trigger a machine software interrupt
+    dispatch();
   }
   EI(intsts);
 }
@@ -254,7 +255,7 @@ void tk_ext_tsk(void) {
 
   /* Update the next task to be scheduled */
   next = tkmc_get_highest_priority_task();
-  out_w(CLINT_MSIP_ADDRESS, 1); // Trigger a machine software interrupt
+  dispatch();
   EI(intsts);
 }
 
@@ -303,7 +304,7 @@ ER tk_rel_wai(ID tskid) {
 
     next = tkmc_get_highest_priority_task();
     if (current != next) {
-      out_w(CLINT_MSIP_ADDRESS, 1);
+      dispatch();
     }
   }
   EI(intsts);

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -64,6 +64,7 @@ typedef struct TCB {
   void *exinf;
   UINT delay_ticks;
   ER wupcause;
+  UINT wupcnt;
 } TCB;
 
 extern TCB *current;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -139,11 +139,20 @@ ER tk_slp_tsk(TMO tmout) {
     current->wupcnt -= 1;
     ercd = E_OK;
     EI(intsts);
+    return ercd;
   } else {
     if (tmout > 0) {
       schedule_timer(current, ((tmout + 9) / 10) + 1, TTW_SLP);
+    } else if (tmout == TMO_POL) {
+      EI(intsts);
+      return E_TMOUT;
     } else {
-      //! @todo implement
+      current->tskstat = TTS_WAI;
+      current->tskwait = TTW_SLP;
+      current->delay_ticks = 0;
+      tkmc_list_del(&current->head);
+      next = tkmc_get_highest_priority_task();
+      out_w(CLINT_MSIP_ADDRESS, 1);
     }
     EI(intsts);
     // wait to be awaken

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -3,6 +3,7 @@
 // clang-format on
 #include "timer.h"
 #include "asm/rv32/address.h"
+#include "dispatch.h"
 #include "list.h"
 #include "task.h"
 
@@ -63,7 +64,7 @@ void tkmc_timer_handler(void) {
         /* Update the next task to be scheduled */
         next = tkmc_get_highest_priority_task();
         if (next != current) {
-          out_w(CLINT_MSIP_ADDRESS, 1); // Trigger a machine software interrupt
+          dispatch();
         }
       }
     }
@@ -89,7 +90,7 @@ static void schedule_timer(TCB *tcb, UINT delay_ticks, enum TaskWait tskwait) {
 
   /* Update the next task to be scheduled */
   next = tkmc_get_highest_priority_task();
-  out_w(CLINT_MSIP_ADDRESS, 1); // Trigger a machine software interrupt
+  dispatch();
 }
 
 /*
@@ -152,7 +153,7 @@ ER tk_slp_tsk(TMO tmout) {
       current->delay_ticks = 0;
       tkmc_list_del(&current->head);
       next = tkmc_get_highest_priority_task();
-      out_w(CLINT_MSIP_ADDRESS, 1);
+      dispatch();
     }
     EI(intsts);
     // wait to be awaken

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -93,8 +93,8 @@ static ER schedule_timer(TCB *tcb, UINT delay_ticks, enum TaskWait tskwait) {
   next = tkmc_get_highest_priority_task();
   out_w(CLINT_MSIP_ADDRESS, 1); // Trigger a machine software interrupt
   EI(intsts);
-  DI(intsts);
   // wait to be awaken
+  DI(intsts);
   ER ercd = ((volatile TCB *)current)->wupcause;
   EI(intsts);
   return ercd;
@@ -125,4 +125,12 @@ ER tk_dly_tsk(TMO dlytm) {
     ercd = E_OK;
   }
   return ercd;
+}
+
+ER tk_slp_tsk(TMO tmout) {
+  if (tmout < TMO_FEVR) {
+    return E_PAR;
+  }
+
+  return E_OK;
 }

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -132,5 +132,26 @@ ER tk_slp_tsk(TMO tmout) {
     return E_PAR;
   }
 
-  return E_OK;
+  UINT intsts;
+  ER ercd = E_OK;
+  DI(intsts);
+  if (current->wupcnt > 0) {
+    current->wupcnt -= 1;
+    ercd = E_OK;
+    EI(intsts);
+  } else {
+    if (tmout > 0) {
+      schedule_timer(current, ((tmout + 9) / 10) + 1, TTW_SLP);
+    } else {
+      //! @todo implement
+    }
+    EI(intsts);
+    // wait to be awaken
+    DI(intsts);
+    ercd = ((volatile TCB *)current)->wupcause;
+    current->wupcause = E_OK;
+    EI(intsts);
+  }
+
+  return ercd;
 }

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -119,6 +119,7 @@ ER tk_dly_tsk(TMO dlytm) {
   // wait to be awaken
   DI(intsts);
   ER ercd = ((volatile TCB *)current)->wupcause;
+  current->wupcause = E_OK;
   EI(intsts);
   if (ercd == E_TMOUT) {
     ercd = E_OK;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -152,6 +152,7 @@ ER tk_slp_tsk(TMO tmout) {
       current->tskwait = TTW_SLP;
       current->delay_ticks = 0;
       tkmc_list_del(&current->head);
+      tkmc_init_list_head(&current->head);
       next = tkmc_get_highest_priority_task();
       dispatch();
     }

--- a/task1.c
+++ b/task1.c
@@ -16,7 +16,7 @@ void task1(INT stacd, void *exinf) {
     if (msg[0] == 'H') {
       ercd = tk_dly_tsk(990);
     } else {
-      ercd = tk_dly_tsk(300);
+      ercd = tk_slp_tsk(300);
     }
     putstring(msg);
     if (stacd == 3) {
@@ -27,6 +27,8 @@ void task1(INT stacd, void *exinf) {
         putstring(" 2\n");
       } else if (ercd == E_RLWAI) {
         putstring(" 3\n");
+      } else if (ercd == E_TMOUT) {
+        putstring(" 4\n");
       } else {
         putstring(" !\n");
       }

--- a/task1.c
+++ b/task1.c
@@ -11,6 +11,7 @@ void task1(INT stacd, void *exinf) {
   putstring("Hello, world\n");
 
   const char *msg = (const char *)exinf;
+  INT c = 0;
   while (1) {
     ER ercd = E_OK;
     if (msg[0] == 'H') {
@@ -20,7 +21,17 @@ void task1(INT stacd, void *exinf) {
     }
     putstring(msg);
     if (stacd == 3) {
-      tk_rel_wai(4);
+      ++c;
+      c %= 2;
+      if (c) {
+        tk_rel_wai(4);
+        tk_rel_wai(4);
+      } else {
+        extern ER tk_wup_tsk(ID);
+        tk_wup_tsk(4);
+        tk_wup_tsk(4);
+        tk_wup_tsk(4);
+      }
       putstring(" 1\n");
     } else {
       if (ercd == E_OK) {


### PR DESCRIPTION

## Description

This update **replaces `state` with `tskstat` and introduces `tskwait`** to improve **task state tracking** in alignment with **uT-Kernel specifications**.

### **Key Changes:**

#### **1. Refactoring Task State Handling**
- **Replaced `state` with `tskstat`** to maintain a **clear distinction** between a task’s overall status and its waiting condition.
- **Introduced `tskwait`** to track specific **waiting conditions** (e.g., waiting for semaphores, delays, or events).

#### **2. Updated Task State Transitions**
- **Updated all functions (`tk_sta_tsk`, `tk_ext_tsk`, `tk_rel_wai`)**:
  - Transitions now **set both `tskstat` and `tskwait` appropriately**.
  - Example: A delayed task will now have:
    ```c
    tcb->tskstat = TTS_WAI;
    tcb->tskwait = TTW_DLY;
    ```
- **Improved `tk_rel_wai()`** to handle various waiting conditions.

#### **3. Timer Queue Adjustments**
- **`tk_dly_tsk()` now explicitly sets `tskwait = TTW_DLY`.**
- **Introduced `schedule_timer()`** to handle timeout-based waiting tasks with precise tracking.

### **Rationale**
- **Improves compatibility** with future uT-Kernel API extensions.
- **Reduces ambiguity** between general task state (`tskstat`) and specific wait conditions (`tskwait`).
- **Prepares the kernel for complex synchronization mechanisms**, including **timeouts, suspensions, and preemptive scheduling**.

This update **ensures precise task management**, making the RTOS more **scalable and maintainable**.
