### PR TITLE
[Feature] Add task2 and update usermain for task management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,12 @@ target_sources(
           kernel/memcpy.c
           kernel/memset.c
           kernel/timer.c
-          task1.c)
+          task1.c
+          task2.c)
 
 # Set CMake compilation flags
 target_compile_options(
-  ${EXECUTABLE} PRIVATE $<$<COMPILE_LANGUAGE:C>:${COMMON_FLAGS}>
+  ${EXECUTABLE} PRIVATE $<$<COMPILE_LANGUAGE:C>:${COMMON_FLAGS} -fstack-usage>
                         $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>)
 
 # Set required standards

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -55,5 +55,6 @@ extern ER tk_sta_tsk(ID tskid, INT stacd);
 extern ER tk_dly_tsk(TMO dlytm);
 extern ER tk_slp_tsk(TMO tmout);
 extern ER tk_rel_wai(ID tskid);
+extern ER tk_wup_tsk(ID tskid);
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/kernel/asm/rv32/idl_tsk.S
+++ b/kernel/asm/rv32/idl_tsk.S
@@ -9,6 +9,5 @@
   .balign 4
 tkmc_idl_tsk:
 1:
-  li a0, 0
-  call tk_dly_tsk
+  call tkmc_yield
   j 1b

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -7,18 +7,37 @@
 #include <tk/tkernel.h>
 
 extern void task1(INT stacd, void *exinf);
+extern void task2(INT stacd, void *exinf);
 
-static UW task1_stack[1024] __attribute__((aligned(16)));
-static UW task2_stack[1024] __attribute__((aligned(16)));
+static UW task1_stack[256] __attribute__((aligned(16)));
+static UW task2_stack[256] __attribute__((aligned(16)));
 
-static const char hello_world[] = "Hello, world.";
-static const char fizzbuzz[] = "FizzBuzz.";
+static ID s_id_map[2] = {
+    0,
+    0,
+};
+
+enum TASK_INDEX {
+  TASK1 = 0,
+  TASK2 = 1,
+  TASK_NBOF,
+};
+
+ID get_tskid(unsigned int index) {
+  if (index >= TASK_NBOF) {
+    return E_PAR;
+  }
+  return s_id_map[index];
+}
+
+static const char task1_exinf[] = "Task1";
+static const char task2_exinf[] = "Task2";
 
 void usermain(int _a0) __attribute__((weak));
 void usermain(int _a0) {
 
   T_CTSK pk_ctsk1 = {
-      .exinf = (void *)hello_world,
+      .exinf = (void *)task1_exinf,
       .tskatr = TA_USERBUF,
       .task = (FP)task1,
       .itskpri = 2,
@@ -27,9 +46,9 @@ void usermain(int _a0) {
   };
 
   T_CTSK pk_ctsk2 = {
-      .exinf = (void *)fizzbuzz,
+      .exinf = (void *)task2_exinf,
       .tskatr = TA_USERBUF,
-      .task = (FP)task1,
+      .task = (FP)task2,
       .itskpri = 2,
       .stksz = sizeof(task2_stack),
       .bufptr = task2_stack,
@@ -37,6 +56,9 @@ void usermain(int _a0) {
   ID task1_id = tk_cre_tsk(&pk_ctsk1);
   ID task2_id = tk_cre_tsk(&pk_ctsk2);
 
-  tk_sta_tsk(task1_id, task1_id);
-  tk_sta_tsk(task2_id, task2_id);
+  s_id_map[TASK1] = task1_id;
+  s_id_map[TASK2] = task2_id;
+
+  tk_sta_tsk(task1_id, 0);
+  tk_sta_tsk(task2_id, 0);
 }

--- a/linker.ld
+++ b/linker.ld
@@ -42,19 +42,19 @@ SECTIONS
     PROVIDE(_data_end = .);
   } >ram AT>ram
 
-  .sbss : {
+  .sbss (NOLOAD) : {
     . = ALIGN(16);
     PROVIDE(_bss_start = .);
     *(.sbss .sbss.*)
   } >ram AT>ram
 
-  .bss :{
+  .bss (NOLOAD) :{
     . = ALIGN(16);
     *(.bss .bss.*)
     PROVIDE(_bss_end = .);
   } >ram AT>ram
 
-  .stack : {
+  .stack (NOLOAD) : {
     . = ALIGN(16);
     PROVIDE(_stack_start = .);
     . = . + 1024;

--- a/task1.c
+++ b/task1.c
@@ -7,42 +7,35 @@
 
 #include "putstring.h"
 
+extern ID get_tskid(unsigned int index);
+enum TASK_INDEX {
+  TASK1 = 0,
+  TASK2 = 1,
+  TASK_NBOF,
+};
 void task1(INT stacd, void *exinf) {
   putstring("Hello, world\n");
+
+  ID task2_id = get_tskid(TASK2);
 
   const char *msg = (const char *)exinf;
   INT c = 0;
   while (1) {
     ER ercd = E_OK;
-    if (msg[0] == 'H') {
-      ercd = tk_dly_tsk(990);
-    } else {
-      ercd = tk_slp_tsk(300);
-    }
+    ercd = tk_dly_tsk(990);
     putstring(msg);
-    if (stacd == 3) {
-      ++c;
-      c %= 2;
-      if (c) {
-        tk_rel_wai(4);
-        tk_rel_wai(4);
-      } else {
-        extern ER tk_wup_tsk(ID);
-        tk_wup_tsk(4);
-        tk_wup_tsk(4);
-        tk_wup_tsk(4);
-      }
-      putstring(" 1\n");
+
+    ++c;
+    c %= 2;
+
+    if (c) {
+      tk_rel_wai(task2_id);
+      tk_rel_wai(task2_id);
     } else {
-      if (ercd == E_OK) {
-        putstring(" 2\n");
-      } else if (ercd == E_RLWAI) {
-        putstring(" 3\n");
-      } else if (ercd == E_TMOUT) {
-        putstring(" 4\n");
-      } else {
-        putstring(" !\n");
-      }
+      tk_wup_tsk(task2_id);
+      tk_wup_tsk(task2_id);
+      tk_wup_tsk(task2_id);
     }
+    putstring(" TASK1\n");
   }
 }

--- a/task2.c
+++ b/task2.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <tk/tkernel.h>
+
+#include "putstring.h"
+
+extern ID get_tskid(unsigned int index);
+enum TASK_INDEX {
+  TASK1 = 0,
+  TASK2 = 1,
+  TASK_NBOF,
+};
+
+void task2(INT stacd, void *exinf) {
+  putstring("Hello, world\n");
+
+  const char *msg = (const char *)exinf;
+  while (1) {
+    ER ercd = tk_slp_tsk(300);
+    putstring(msg);
+    if (ercd == E_OK) {
+      putstring(" TASK2 E_OK\n");
+    } else if (ercd == E_RLWAI) {
+      putstring(" TASK2 E_RLWAI\n");
+    } else if (ercd == E_TMOUT) {
+      putstring(" TASK2 E_TMOUT\n");
+    } else {
+      putstring(" TASK2 !\n");
+    }
+  }
+}


### PR DESCRIPTION
- Added `task2.c` with a separate task implementation.
- Updated `usermain.c` to manage task IDs using `get_tskid` for better task identification.
- Modified `task1.c` to interact with `task2` using `tk_rel_wai` and `tk_wup_tsk`.
- Adjusted stack sizes for tasks in `usermain.c`.
- Enabled `-fstack-usage` flag in `CMakeLists.txt` for stack analysis.
- Updated `linker.ld` to mark `.bss` and `.stack` sections as `NOLOAD`.