### PR TITLE
 Modularise Kernel Build and Introduce Static Kernel Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(EXECUTABLE ${PROJECT_NAME}.elf)
 # Set common flags for bare-metal
 set(COMMON_FLAGS -ffreestanding -nostdlib -nostdinc)
 
+# Create static library for kernel components
 add_library(
   tsukumo-core-kernel STATIC
   kernel/asm/rv32/start.S
@@ -27,26 +28,35 @@ add_library(
   kernel/memset.c
   kernel/timer.c)
 
+# Set include paths for the kernel library
 target_include_directories(tsukumo-core-kernel
                            PUBLIC include ${CMAKE_BINARY_DIR}/include/)
 
+# Set compile options for the kernel library
 target_compile_options(
   tsukumo-core-kernel
   PRIVATE $<$<COMPILE_LANGUAGE:C>:${COMMON_FLAGS} -fstack-usage>
           $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>)
 
+# Set required language standard for the kernel library
 target_compile_features(tsukumo-core-kernel PRIVATE c_std_11)
 
-# tkmc_macros.cmake
+# Define macro function to create an executable with linked kernel library
 function(tkmc_add_executable exec_name)
+  # Parse arguments, expecting SOURCES keyword
   cmake_parse_arguments(TKMC "" "" "SOURCES" ${ARGN})
 
+  # Define the executable with the given sources
   add_executable(${exec_name} ${TKMC_SOURCES})
+
+  # Link against the prebuilt kernel static library
   target_link_libraries(${exec_name} PRIVATE tsukumo-core-kernel)
 
+  # Add compile-time definitions (e.g. for CONST checking)
   target_compile_definitions(${exec_name} PUBLIC TKERNEL_CHECK_CONST)
 endfunction()
 
+# Add main executable with user task sources
 tkmc_add_executable(${EXECUTABLE} SOURCES task1.c task2.c)
 
 # Set CMake compilation flags
@@ -82,10 +92,10 @@ option(
   "Enable CONST checks to prevent unintended modifications to pointer parameters in system calls. This helps ensure code safety by using 'const' qualifiers when supported. If disabled, CONST will be defined as an empty macro to maintain compatibility with legacy code."
   ON)
 
-# Include external script
+# Include external script for type determination
 include(DetermineTypes.cmake)
 
-# Generate typedef.h
+# Generate typedef.h from template
 configure_file(typedef.h.in ${CMAKE_BINARY_DIR}/include/tk/typedef.h @ONLY)
 
 # Add compile definitions based on options
@@ -109,8 +119,6 @@ else()
 
   # Set the kernel image path (kernel is tsukumo-core.elf in CMAKE_BINARY_DIR).
   set(KERNEL_IMAGE "${CMAKE_BINARY_DIR}/tsukumo-core.elf")
-
-  # Set the script output directory (using CMAKE_BINARY_DIR).
 
   # Generate Linux shell scripts.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,23 +14,40 @@ set(EXECUTABLE ${PROJECT_NAME}.elf)
 # Set common flags for bare-metal
 set(COMMON_FLAGS -ffreestanding -nostdlib -nostdinc)
 
-# Specify the executable
-add_executable(${EXECUTABLE})
+add_library(
+  tsukumo-core-kernel STATIC
+  kernel/asm/rv32/start.S
+  kernel/asm/rv32/launch_task.S
+  kernel/asm/rv32/idl_tsk.S
+  kernel/start.c
+  kernel/task.c
+  kernel/ini_tsk.c
+  kernel/usermain.c
+  kernel/memcpy.c
+  kernel/memset.c
+  kernel/timer.c)
 
-target_sources(
-  ${EXECUTABLE}
-  PRIVATE kernel/asm/rv32/start.S
-          kernel/asm/rv32/launch_task.S
-          kernel/asm/rv32/idl_tsk.S
-          kernel/start.c
-          kernel/task.c
-          kernel/ini_tsk.c
-          kernel/usermain.c
-          kernel/memcpy.c
-          kernel/memset.c
-          kernel/timer.c
-          task1.c
-          task2.c)
+target_include_directories(tsukumo-core-kernel
+                           PUBLIC include ${CMAKE_BINARY_DIR}/include/)
+
+target_compile_options(
+  tsukumo-core-kernel
+  PRIVATE $<$<COMPILE_LANGUAGE:C>:${COMMON_FLAGS} -fstack-usage>
+          $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>)
+
+target_compile_features(tsukumo-core-kernel PRIVATE c_std_11)
+
+# tkmc_macros.cmake
+function(tkmc_add_executable exec_name)
+  cmake_parse_arguments(TKMC "" "" "SOURCES" ${ARGN})
+
+  add_executable(${exec_name} ${TKMC_SOURCES})
+  target_link_libraries(${exec_name} PRIVATE tsukumo-core-kernel)
+
+  target_compile_definitions(${exec_name} PUBLIC TKERNEL_CHECK_CONST)
+endfunction()
+
+tkmc_add_executable(${EXECUTABLE} SOURCES task1.c task2.c)
 
 # Set CMake compilation flags
 target_compile_options(
@@ -38,11 +55,7 @@ target_compile_options(
                         $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>)
 
 # Set required standards
-target_compile_features(${EXECUTABLE} PRIVATE c_std_11 cxx_std_20)
-
-# Add include directories (if needed)
-target_include_directories(${EXECUTABLE} PRIVATE include
-                                                 ${CMAKE_BINARY_DIR}/include/)
+target_compile_features(${EXECUTABLE} PRIVATE c_std_11)
 
 # Convert to BIN file
 add_custom_command(

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -50,7 +50,7 @@ typedef struct T_CTSK {
 } T_CTSK;
 
 extern void tk_ext_tsk(void);
-extern ID tk_cre_tsk(const T_CTSK *pk_ctsk);
+extern ID tk_cre_tsk(CONST T_CTSK *pk_ctsk);
 extern ER tk_sta_tsk(ID tskid, INT stacd);
 extern ER tk_dly_tsk(TMO dlytm);
 extern ER tk_slp_tsk(TMO tmout);


### PR DESCRIPTION
## Description

This commit refactors the build system to separate **kernel components** into a static library (`tsukumo-core-kernel`) and introduces a macro-based interface for adding user-defined executables.

### Key Changes:

- **Create `tsukumo-core-kernel` static library**
  - Includes all core kernel sources: boot assembly, task management, timer, memory functions, etc.
  - Encapsulates common compiler flags and include paths.

- **Introduce `tkmc_add_executable()` macro**
  - Simplifies creation of executables by linking to the kernel library automatically.
  - Supports modular user task development.

- **Refactor `typedef.h` generation**
  - Keeps script-based `typedef.h` creation intact via `configure_file()`.

- **Update build configuration**
  - Enforce C11 standard for all targets.
  - Remove redundant includes and flags from the main executable.

- **Fix `tk_cre_tsk` prototype**
  - Add `CONST` qualifier for `pk_ctsk` parameter to match implementation.

## Rationale

This modular approach:
- Encourages reuse and testability of kernel components.
- Simplifies user task compilation and linking.
- Prepares the build system for future expansion (e.g. apps, tests).
