### PR TITLE
Integrate Event Flag Mechanism and Add Task3/4 for Synchronisation Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ function(tkmc_add_executable exec_name)
 endfunction()
 
 # Add main executable with user task sources
-tkmc_add_executable(${EXECUTABLE} SOURCES task1.c task2.c task3.c)
+tkmc_add_executable(${EXECUTABLE} SOURCES task1.c task2.c task3.c task4.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ function(tkmc_add_executable exec_name)
 endfunction()
 
 # Add main executable with user task sources
-tkmc_add_executable(${EXECUTABLE} SOURCES task1.c task2.c)
+tkmc_add_executable(${EXECUTABLE} SOURCES task1.c task2.c task3.c)
 
 # Set CMake compilation flags
 target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ add_library(
   kernel/usermain.c
   kernel/memcpy.c
   kernel/memset.c
-  kernel/timer.c)
+  kernel/timer.c
+  kernel/event_flag.c)
 
 # Set include paths for the kernel library
 target_include_directories(tsukumo-core-kernel

--- a/include/sys/config.h
+++ b/include/sys/config.h
@@ -32,6 +32,7 @@ _Static_assert(CFN_MAX_PRI >= 16, "CFN_MAX_PRI must be greater than or equal to 
 
 /* Maximum number of event flags */
 #define CFN_MAX_FLGID 16
+_Static_assert(CFN_MAX_FLGID < 0x80000000, "CFN_MAX_FLGID must be less than 2147483648 (0x80000000).");
 
 /* Maximum number of mailboxes */
 // #define CFN_MAX_MBXID 8

--- a/include/sys/config.h
+++ b/include/sys/config.h
@@ -31,7 +31,7 @@ _Static_assert(CFN_MAX_PRI >= 16, "CFN_MAX_PRI must be greater than or equal to 
 // #define CFN_MAX_SEMID 16
 
 /* Maximum number of event flags */
-// #define CFN_MAX_FLGID 16
+#define CFN_MAX_FLGID 16
 
 /* Maximum number of mailboxes */
 // #define CFN_MAX_MBXID 8

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -72,7 +72,7 @@ typedef struct T_CFLG {
 extern ID tk_cre_flg(CONST T_CFLG *pk_cflg);
 // extern ER tk_set_flg(ID flgid, UINT setptn);
 // extern ER tk_clr_flg(ID flgid, UINT clrptn);
-// extern ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn,
-//                      TMO tmout);
+extern ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn,
+                     TMO tmout);
 
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -63,4 +63,10 @@ extern ER tk_slp_tsk(TMO tmout);
 extern ER tk_rel_wai(ID tskid);
 extern ER tk_wup_tsk(ID tskid);
 
+typedef struct T_CFLG {
+  void *exinf;  /* Extended Information */
+  ATR flgattr;  /* EventFlag Attribute*/
+  UINT iflgptn; /* Initial EventFlag Pattern */
+} T_CFLG;
+
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -46,6 +46,38 @@
 #define TA_WMUL 0x00000008     /* Allow waiting of multiple tasks */
 #define TA_NODISWAI 0x00000080 /* Prohibit wait disable */
 
+#define TTS_NOEXS 0x0000
+#define TTS_RUN 0x0001
+#define TTS_RDY 0x0002
+#define TTS_WAI 0x0004
+#define TTS_SUS 0x0008
+#define TTS_WAS 0x000c
+#define TTS_DMT 0x0010
+#define TTS_NODISWAI 0x0080
+
+#define TTW_SLP 0x00000001  /**< Waiting due to `tk_slp_tsk` */
+#define TTW_DLY 0x00000002  /**< Waiting due to `tk_dly_tsk` */
+#define TTW_SEM 0x00000004  /**< Waiting due to `tk_wai_sem` */
+#define TTW_FLG 0x00000008  /**< Waiting due to `tk_wai_flg` */
+#define TTW_MBX 0x00000040  /**< Waiting due to `tk_rcv_mbx` */
+#define TTW_MTX 0x00000080  /**< Waiting due to `tk_loc_mtx` */
+#define TTW_SMBF 0x00000100 /**< Waiting due to `tk_snd_mbf` */
+#define TTW_RMBF 0x00000200 /**< Waiting due to `tk_rcv_mbf` */
+// #define TTW_CAL   0x00000400  Reserved
+// #define TTW_ACP   0x00000800  Reserved
+// #define TTW_RDV   0x00001000  Reserved
+// #define TTW_CAL_RDV  TTW_CAL|TTW_RDV  Reserved
+#define TTW_MPF 0x00002000 /**< Waiting due to `tk_get_mpf` */
+#define TTW_MPL 0x00004000 /**< Waiting due to `tk_get_mpl` */
+#define TTW_EV1 0x00010000 /**< Waiting for Task Event #1 */
+#define TTW_EV2 0x00020000 /**< Waiting for Task Event #2 */
+#define TTW_EV3 0x00040000 /**< Waiting for Task Event #3 */
+#define TTW_EV4 0x00080000 /**< Waiting for Task Event #4 */
+#define TTW_EV5 0x00100000 /**< Waiting for Task Event #5 */
+#define TTW_EV6 0x00200000 /**< Waiting for Task Event #6 */
+#define TTW_EV7 0x00400000 /**< Waiting for Task Event #7 */
+#define TTW_EV8 0x00800000 /**< Waiting for Task Event #8 */
+
 #define TWF_ANDW 0x00   /* AND wait */
 #define TWF_ORW 0x01    /* OR wait */
 #define TWF_CLR 0x10    /* Clear all */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -65,7 +65,7 @@ extern ER tk_wup_tsk(ID tskid);
 
 typedef struct T_CFLG {
   void *exinf;  /* Extended Information */
-  ATR flgattr;  /* EventFlag Attribute*/
+  ATR flgatr;   /* EventFlag Attribute*/
   UINT iflgptn; /* Initial EventFlag Pattern */
 } T_CFLG;
 

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -40,6 +40,12 @@
 #define TA_COP2 0x00004000U /* Use coprocessor (ID=2) */
 #define TA_COP3 0x00008000U /* Use coprocessor (ID=3) */
 
+#define TA_TFIFO 0x00000000    /* Manage waiting tasks in FIFO order */
+#define TA_TPRI 0x00000001     /* Manage waiting tasks in order of priority */
+#define TA_WSGL 0x00000000     /* Do not allow waiting of multiple tasks */
+#define TA_WMUL 0x00000008     /* Allow waiting of multiple tasks */
+#define TA_NODISWAI 0x00000080 /* Prohibit wait disable */
+
 typedef struct T_CTSK {
   void *exinf;  /* Extended Information */
   ATR tskatr;   /* Task Attribute  */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -108,7 +108,7 @@ typedef struct T_CFLG {
 
 extern ID tk_cre_flg(CONST T_CFLG *pk_cflg);
 extern ER tk_set_flg(ID flgid, UINT setptn);
-// extern ER tk_clr_flg(ID flgid, UINT clrptn);
+extern ER tk_clr_flg(ID flgid, UINT clrptn);
 extern ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn,
                      TMO tmout);
 

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -69,4 +69,10 @@ typedef struct T_CFLG {
   UINT iflgptn; /* Initial EventFlag Pattern */
 } T_CFLG;
 
+extern ID tk_cre_flg(CONST T_CFLG *pk_cflg);
+// extern ER tk_set_flg(ID flgid, UINT setptn);
+// extern ER tk_clr_flg(ID flgid, UINT clrptn);
+// extern ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn,
+//                      TMO tmout);
+
 #endif /* UUID_01946FAC_8E45_7658_B009_C10ED747A05C */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -46,6 +46,11 @@
 #define TA_WMUL 0x00000008     /* Allow waiting of multiple tasks */
 #define TA_NODISWAI 0x00000080 /* Prohibit wait disable */
 
+#define TWF_ANDW 0x00   /* AND wait */
+#define TWF_ORW 0x01    /* OR wait */
+#define TWF_CLR 0x10    /* Clear all */
+#define TWF_BITCLR 0x20 /* Clear only condition bits */
+
 typedef struct T_CTSK {
   void *exinf;  /* Extended Information */
   ATR tskatr;   /* Task Attribute  */

--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -107,7 +107,7 @@ typedef struct T_CFLG {
 } T_CFLG;
 
 extern ID tk_cre_flg(CONST T_CFLG *pk_cflg);
-// extern ER tk_set_flg(ID flgid, UINT setptn);
+extern ER tk_set_flg(ID flgid, UINT setptn);
 // extern ER tk_clr_flg(ID flgid, UINT clrptn);
 extern ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn,
                      TMO tmout);

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -138,12 +138,17 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
     if (tkmc_list_empty(&flgcb->wait_queue) != FALSE) {
       tkmc_list_add_tail(&tcb->winfo.wait_queue, &flgcb->wait_queue);
     } else {
+      BOOL inserted = FALSE;
       TCB *pos;
       tkmc_list_for_each_entry(pos, &flgcb->wait_queue, winfo.wait_queue) {
         if (tcb->itskpri < pos->itskpri) {
           tkmc_list_add(&tcb->winfo.wait_queue, pos->winfo.wait_queue.prev);
+          inserted = TRUE;
           break;
         }
+      }
+      if (inserted == FALSE) {
+        tkmc_list_add_tail(&tcb->winfo.wait_queue, &flgcb->wait_queue);
       }
     }
   } else {

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -63,3 +63,7 @@ ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
 
   return new_flgid;
 }
+
+ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
+  return E_TMOUT;
+}

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <tk/tkernel.h>
+
+#include "event_flag.h"

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -113,7 +113,11 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
       }
       ercd = E_OK;
     } else {
-      ercd = E_TMOUT;
+      if (tmout == TMO_POL) {
+        ercd = E_TMOUT;
+      } else {
+        ercd = E_TMOUT; // temporary
+      }
     }
   }
   EI(intsts);

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -28,4 +28,13 @@ void tkmc_init_flgcb(void) {
   }
 }
 
-ID tk_cre_flg(CONST T_CFLG *pk_cflg) { return E_LIMIT; }
+ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
+  const ATR flgatr = pk_cflg->flgatr;
+  static const ATR VALID_FLGATR = TA_TFIFO | TA_TPRI | TA_WSGL | TA_WMUL;
+
+  if ((flgatr & ~VALID_FLGATR) != 0) {
+    return E_RSATR;
+  }
+
+  return E_LIMIT;
+}

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -82,5 +82,19 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
     return E_PAR;
   }
 
-  return E_TMOUT;
+  ER ercd = E_OK;
+  FLGCB *flgcb = &tkmc_flgcbs[flgid - 1];
+
+  UINT intsts = 0;
+  DI(intsts);
+  if ((flgcb->flgid & NOEXS_MASK) != 0) {
+    ercd = E_NOEXS;
+  }
+
+  if (ercd == E_OK) {
+    ercd = E_TMOUT;
+  }
+  EI(intsts);
+
+  return ercd;
 }

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -36,5 +36,30 @@ ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
     return E_RSATR;
   }
 
-  return E_LIMIT;
+  if (flgatr & TA_TPRI || flgatr & TA_WMUL) {
+    return E_NOMEM; // temporary
+  }
+
+  UINT intsts = 0;
+  FLGCB *new_flgcb = NULL;
+  ID new_flgid = 0;
+  DI(intsts);
+
+  if (tkmc_list_empty(&tkmc_free_flbcb) == FALSE) {
+    /* Allocate a TCB from the free list */
+    new_flgcb = tkmc_list_first_entry(&tkmc_free_flbcb, FLGCB, wait_queue);
+    tkmc_list_del(&new_flgcb->wait_queue);
+    tkmc_init_list_head(&new_flgcb->wait_queue);
+    new_flgid = new_flgcb->flgid;
+
+    new_flgcb->exinf = pk_cflg->exinf;
+    new_flgcb->flgatr = pk_cflg->flgatr;
+    new_flgcb->flgptn = pk_cflg->iflgptn;
+  } else {
+    new_flgid = (ID)E_LIMIT;
+  }
+
+  EI(intsts);
+
+  return new_flgid;
 }

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -11,7 +11,7 @@
 FLGCB tkmc_flbcbs[CFN_MAX_FLGID];
 static tkmc_list_head tkmc_free_flbcb;
 
-void tkmc_init_flbcb(void) {
+void tkmc_init_flgcb(void) {
   tkmc_init_list_head(&tkmc_free_flbcb);
 
   for (int i = 0; i < sizeof(tkmc_flbcbs) / sizeof(tkmc_flbcbs[0]); ++i) {

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -115,6 +115,10 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
     } else {
       if (tmout == TMO_POL) {
         ercd = E_TMOUT;
+      } else if (tmout > 0) {
+        ercd = E_TMOUT; // temporary
+      } else if (tmout == TMO_FEVR) {
+        ercd = E_TMOUT; // temporary
       } else {
         ercd = E_TMOUT; // temporary
       }

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -128,3 +128,26 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
 
   return ercd;
 }
+
+ER tk_set_flg(ID flgid, UINT setptn) {
+  if (flgid > CFN_MAX_FLGID) {
+    return E_ID;
+  }
+  
+  ER ercd = E_OK;
+  FLGCB *flgcb = &tkmc_flgcbs[flgid - 1];
+
+  UINT intsts = 0;
+  DI(intsts);
+  if ((flgcb->flgid & NOEXS_MASK) != 0) {
+    ercd = E_NOEXS;
+  }
+
+  if (ercd == E_OK) {
+    flgcb->flgptn |= setptn;
+  }
+
+  EI(intsts);
+
+  return E_OK;
+}

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -7,3 +7,23 @@
 #include <tk/tkernel.h>
 
 #include "event_flag.h"
+
+FLGCB tkmc_flbcbs[CFN_MAX_FLGID];
+static tkmc_list_head tkmc_free_flbcb;
+
+void tkmc_init_flbcb(void) {
+  tkmc_init_list_head(&tkmc_free_flbcb);
+
+  for (int i = 0; i < sizeof(tkmc_flbcbs) / sizeof(tkmc_flbcbs[0]); ++i) {
+    FLGCB *flgcb = &tkmc_flbcbs[i];
+    *flgcb = (FLGCB){
+        .flgid = i + 1,
+        .exinf = NULL,
+        .attr = 0,
+        .flgptn = 0,
+    };
+    tkmc_init_list_head(&flgcb->wait_queue);
+
+    tkmc_list_add_tail(&flgcb->wait_queue, &tkmc_free_flbcb);
+  }
+}

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -8,14 +8,14 @@
 
 #include "event_flag.h"
 
-FLGCB tkmc_flbcbs[CFN_MAX_FLGID];
+FLGCB tkmc_flgcbs[CFN_MAX_FLGID];
 static tkmc_list_head tkmc_free_flbcb;
 
 void tkmc_init_flgcb(void) {
   tkmc_init_list_head(&tkmc_free_flbcb);
 
-  for (int i = 0; i < sizeof(tkmc_flbcbs) / sizeof(tkmc_flbcbs[0]); ++i) {
-    FLGCB *flgcb = &tkmc_flbcbs[i];
+  for (int i = 0; i < sizeof(tkmc_flgcbs) / sizeof(tkmc_flgcbs[0]); ++i) {
+    FLGCB *flgcb = &tkmc_flgcbs[i];
     *flgcb = (FLGCB){
         .flgid = i + 1,
         .exinf = NULL,

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -11,13 +11,15 @@
 FLGCB tkmc_flgcbs[CFN_MAX_FLGID];
 static tkmc_list_head tkmc_free_flbcb;
 
+#define NOEXS_MASK 0x80000000u
+
 void tkmc_init_flgcb(void) {
   tkmc_init_list_head(&tkmc_free_flbcb);
 
   for (int i = 0; i < sizeof(tkmc_flgcbs) / sizeof(tkmc_flgcbs[0]); ++i) {
     FLGCB *flgcb = &tkmc_flgcbs[i];
     *flgcb = (FLGCB){
-        .flgid = i + 1,
+        .flgid = (i + 1) | NOEXS_MASK,
         .exinf = NULL,
         .flgatr = 0,
         .flgptn = 0,
@@ -50,8 +52,9 @@ ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
     new_flgcb = tkmc_list_first_entry(&tkmc_free_flbcb, FLGCB, wait_queue);
     tkmc_list_del(&new_flgcb->wait_queue);
     tkmc_init_list_head(&new_flgcb->wait_queue);
-    new_flgid = new_flgcb->flgid;
+    new_flgid = new_flgcb->flgid & ~NOEXS_MASK;
 
+    new_flgcb->flgid = new_flgid;
     new_flgcb->exinf = pk_cflg->exinf;
     new_flgcb->flgatr = pk_cflg->flgatr;
     new_flgcb->flgptn = pk_cflg->iflgptn;

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -11,16 +11,27 @@
 #include "task.h"
 #include "timer.h"
 
+// Event flag control block table
 FLGCB tkmc_flgcbs[CFN_MAX_FLGID];
+
+// Free list of unused event flag control blocks
 static tkmc_list_head tkmc_free_flbcb;
 
+// Bitmask used to mark control blocks as non-existent
 #define NOEXS_MASK 0x80000000u
 
+/**
+ * @brief Initialize the event flag control block table.
+ *
+ * Set up all FLGCBs as unallocated and add them to the free list.
+ */
 void tkmc_init_flgcb(void) {
   tkmc_init_list_head(&tkmc_free_flbcb);
 
   for (int i = 0; i < sizeof(tkmc_flgcbs) / sizeof(tkmc_flgcbs[0]); ++i) {
     FLGCB *flgcb = &tkmc_flgcbs[i];
+
+    // Initialize all fields with default values and mark as non-existent
     *flgcb = (FLGCB){
         .flgid = (i + 1) | NOEXS_MASK,
         .exinf = NULL,
@@ -29,14 +40,22 @@ void tkmc_init_flgcb(void) {
     };
     tkmc_init_list_head(&flgcb->wait_queue);
 
+    // Add to free list
     tkmc_list_add_tail(&flgcb->wait_queue, &tkmc_free_flbcb);
   }
 }
 
+/**
+ * @brief Create an event flag object.
+ *
+ * @param pk_cflg Pointer to the creation parameter structure
+ * @return ID of the created flag, or error code
+ */
 ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
   const ATR flgatr = pk_cflg->flgatr;
   static const ATR VALID_FLGATR = TA_TFIFO | TA_TPRI | TA_WSGL | TA_WMUL;
 
+  // Check if attribute contains any invalid bits
   if ((flgatr & ~VALID_FLGATR) != 0) {
     return E_RSATR;
   }
@@ -44,13 +63,15 @@ ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
   UINT intsts = 0;
   FLGCB *new_flgcb = NULL;
   ID new_flgid = 0;
-  DI(intsts);
+  DI(intsts); // Disable interrupts to access shared structures
 
   if (tkmc_list_empty(&tkmc_free_flbcb) == FALSE) {
-    /* Allocate a TCB from the free list */
+    // Allocate a FLGCB from the free list
     new_flgcb = tkmc_list_first_entry(&tkmc_free_flbcb, FLGCB, wait_queue);
     tkmc_list_del(&new_flgcb->wait_queue);
     tkmc_init_list_head(&new_flgcb->wait_queue);
+
+    // Update flag ID to mark as valid
     new_flgid = new_flgcb->flgid & ~NOEXS_MASK;
 
     new_flgcb->flgid = new_flgid;
@@ -58,14 +79,23 @@ ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
     new_flgcb->flgatr = pk_cflg->flgatr;
     new_flgcb->flgptn = pk_cflg->iflgptn;
   } else {
+    // No available FLGCBs
     new_flgid = (ID)E_LIMIT;
   }
 
-  EI(intsts);
+  EI(intsts); // Restore interrupts
 
   return new_flgid;
 }
 
+/**
+ * @brief Check if the flag pattern matches the waiting pattern and mode.
+ *
+ * @param flgptn Current flag pattern
+ * @param waiptn Waiting pattern
+ * @param wfmode Waiting mode (AND/OR)
+ * @return TRUE if condition is met
+ */
 static BOOL check_ptn(UINT flgptn, UINT waiptn, UINT wfmode) {
   BOOL cond;
   if ((wfmode & TWF_ANDW) != 0) {
@@ -76,13 +106,18 @@ static BOOL check_ptn(UINT flgptn, UINT waiptn, UINT wfmode) {
   return cond ? TRUE : FALSE;
 }
 
+/**
+ * @brief Wait for event flag.
+ */
 ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
+  // Basic validation
   if (flgid > CFN_MAX_FLGID) {
     return E_ID;
   }
   if (waiptn == 0) {
     return E_PAR;
   }
+
   static const UINT VALID_WFMODE = TWF_ANDW | TWF_ORW | TWF_CLR | TWF_BITCLR;
   if ((wfmode & ~VALID_WFMODE) != 0) {
     return E_PAR;
@@ -96,6 +131,8 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
 
   UINT intsts = 0;
   DI(intsts);
+
+  // Check existence
   if ((flgcb->flgid & NOEXS_MASK) != 0) {
     EI(intsts);
     return E_NOEXS;
@@ -103,37 +140,43 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
 
   UINT flgptn = flgcb->flgptn;
 
+  // Immediate condition check
   if (check_ptn(flgptn, waiptn, wfmode) != FALSE) {
     *p_flgptn = flgptn;
+
+    // Clear pattern if requested
     if ((wfmode & TWF_CLR) != 0) {
       flgcb->flgptn = 0;
     } else if ((wfmode & TWF_BITCLR) != 0) {
       flgcb->flgptn &= ~waiptn;
     }
+
     EI(intsts);
     return E_OK;
   }
 
+  // No wait requested (polling)
   if (tmout == TMO_POL) {
     EI(intsts);
     return E_TMOUT;
   }
 
   TCB *tcb = current;
-  if ((flgcb->flgatr & TA_WMUL) == 0) {
-    if (!tkmc_list_empty(&flgcb->wait_queue)) {
-      EI(intsts);
-      return E_OBJ;
-    }
+
+  // Check for single-wait restriction
+  if ((flgcb->flgatr & TA_WMUL) == 0 && !tkmc_list_empty(&flgcb->wait_queue)) {
+    EI(intsts);
+    return E_OBJ;
   }
 
-  // Set wait information
+  // Setup wait parameters
   tcb->winfo.waiptn = waiptn;
   tcb->winfo.wfmode = wfmode;
   tcb->winfo.flgptn = 0;
 
-  tkmc_init_list_head(&tcb->winfo.wait_queue); // Initialize for safety
+  tkmc_init_list_head(&tcb->winfo.wait_queue); // For safety
 
+  // Insert into wait queue based on priority or FIFO
   if (flgcb->flgatr & TA_TPRI) {
     if (tkmc_list_empty(&flgcb->wait_queue) != FALSE) {
       tkmc_list_add_tail(&tcb->winfo.wait_queue, &flgcb->wait_queue);
@@ -154,9 +197,10 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
   } else {
     tkmc_list_add_tail(&tcb->winfo.wait_queue, &flgcb->wait_queue);
   }
+
   if (tmout > 0) {
-    tkmc_schedule_timer(tcb, ((tmout + 9) / 10) + 1,
-                        TTW_FLG); // Convert to ticks
+    // Start timer if timeout is specified
+    tkmc_schedule_timer(tcb, ((tmout + 9) / 10) + 1, TTW_FLG);
   } else {
     // Infinite wait
     tcb->tskstat = TTS_WAI;
@@ -165,12 +209,12 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
     tkmc_list_del(&tcb->head);
     tkmc_init_list_head(&tcb->head);
     next = tkmc_get_highest_priority_task();
-    dispatch();
+    dispatch(); // Perform task switch
   }
 
   EI(intsts);
 
-  // Block until the wait is released (resumed by an interrupt)
+  // Wait here until resumed by event or timeout
   DI(intsts);
   ercd = ((volatile TCB *)current)->wupcause;
   if (ercd == E_OK) {
@@ -182,6 +226,9 @@ ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
   return ercd;
 }
 
+/**
+ * @brief Set bits in the event flag and wake up waiting tasks if matched.
+ */
 ER tk_set_flg(ID flgid, UINT setptn) {
   if (flgid > CFN_MAX_FLGID) {
     return E_ID;
@@ -196,45 +243,47 @@ ER tk_set_flg(ID flgid, UINT setptn) {
     return E_NOEXS;
   }
 
-  // Set the pattern bits
+  // Update flag bits
   flgcb->flgptn |= setptn;
 
   if (!tkmc_list_empty(&flgcb->wait_queue)) {
     TCB *tcb, *n;
+
+    // Check each waiting task and wake up if condition met
     tkmc_list_for_each_entry_safe(tcb, n, &flgcb->wait_queue,
                                   winfo.wait_queue) {
       if (check_ptn(flgcb->flgptn, tcb->winfo.waiptn, tcb->winfo.wfmode)) {
         tkmc_list_del(&tcb->winfo.wait_queue);
 
-        // Remove from timer queue if present
+        // Remove from timer queue if registered
         if (tcb->delay_ticks > 0) {
-          tkmc_list_del(&tcb->head); // Remove from timer queue
+          tkmc_list_del(&tcb->head);
           tcb->delay_ticks = 0;
         }
 
-        // Set result
         tcb->winfo.flgptn = flgcb->flgptn;
         tcb->wupcause = E_OK;
 
-        // Clear pattern
+        // Optional clearing of flags
         if (tcb->winfo.wfmode & TWF_CLR) {
           flgcb->flgptn = 0;
         } else if (tcb->winfo.wfmode & TWF_BITCLR) {
           flgcb->flgptn &= ~(tcb->winfo.waiptn);
         }
 
-        // State transition
+        // Move task to ready state
         tcb->tskstat = TTS_RDY;
         tcb->tskwait = 0;
         tkmc_list_add_tail(&tcb->head, &tkmc_ready_queue[tcb->itskpri - 1]);
 
+        // If only one task should be woken (TA_WSGL), stop here
         if ((flgcb->flgatr & TA_WSGL) != 0) {
           break;
         }
       }
     }
 
-    // Context switch if a higher-priority task is ready
+    // Trigger context switch if a higher-priority task became ready
     next = tkmc_get_highest_priority_task();
     if (next != current) {
       dispatch();
@@ -246,6 +295,9 @@ ER tk_set_flg(ID flgid, UINT setptn) {
   return E_OK;
 }
 
+/**
+ * @brief Clear specific bits in the event flag.
+ */
 ER tk_clr_flg(ID flgid, UINT clrptn) {
   if (flgid <= 0 || flgid > CFN_MAX_FLGID) {
     return E_ID;
@@ -260,7 +312,7 @@ ER tk_clr_flg(ID flgid, UINT clrptn) {
     return E_NOEXS;
   }
 
-  // Clear the specified pattern bits
+  // Clear specified bits from the flag pattern
   flgcb->flgptn &= ~clrptn;
 
   EI(intsts);

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -68,5 +68,19 @@ ID tk_cre_flg(CONST T_CFLG *pk_cflg) {
 }
 
 ER tk_wai_flg(ID flgid, UINT waiptn, UINT wfmode, UINT *p_flgptn, TMO tmout) {
+  if (flgid > CFN_MAX_FLGID) {
+    return E_ID;
+  }
+  if (waiptn == 0) {
+    return E_PAR;
+  }
+  static const UINT VALID_WFMODE = TWF_ANDW | TWF_ORW | TWF_CLR | TWF_BITCLR;
+  if ((wfmode & ~VALID_WFMODE) != 0) {
+    return E_PAR;
+  }
+  if (tmout < TMO_FEVR) {
+    return E_PAR;
+  }
+
   return E_TMOUT;
 }

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -19,7 +19,7 @@ void tkmc_init_flgcb(void) {
     *flgcb = (FLGCB){
         .flgid = i + 1,
         .exinf = NULL,
-        .attr = 0,
+        .flgatr = 0,
         .flgptn = 0,
     };
     tkmc_init_list_head(&flgcb->wait_queue);

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -240,3 +240,24 @@ ER tk_set_flg(ID flgid, UINT setptn) {
 
   return E_OK;
 }
+
+ER tk_clr_flg(ID flgid, UINT clrptn) {
+  if (flgid <= 0 || flgid > CFN_MAX_FLGID) {
+    return E_ID;
+  }
+
+  FLGCB *flgcb = &tkmc_flgcbs[flgid - 1];
+  UINT intsts = 0;
+  DI(intsts);
+
+  if ((flgcb->flgid & NOEXS_MASK) != 0) {
+    EI(intsts);
+    return E_NOEXS;
+  }
+
+  // Clear the specified pattern bits
+  flgcb->flgptn &= ~clrptn;
+
+  EI(intsts);
+  return E_OK;
+}

--- a/kernel/event_flag.c
+++ b/kernel/event_flag.c
@@ -27,3 +27,5 @@ void tkmc_init_flgcb(void) {
     tkmc_list_add_tail(&flgcb->wait_queue, &tkmc_free_flbcb);
   }
 }
+
+ID tk_cre_flg(CONST T_CFLG *pk_cflg) { return E_LIMIT; }

--- a/kernel/event_flag.h
+++ b/kernel/event_flag.h
@@ -23,7 +23,7 @@ typedef struct FLGCB {
   UINT flgptn;
 } FLGCB;
 
-extern void tkmc_init_flbcb(void);
+extern void tkmc_init_flgcb(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/event_flag.h
+++ b/kernel/event_flag.h
@@ -7,9 +7,23 @@
 #ifndef UUID_0195C76B_33EA_715C_A3A4_72FC38355057
 #define UUID_0195C76B_33EA_715C_A3A4_72FC38355057
 
+#include <tk/tkernel.h>
+
+#include "list.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+typedef struct FLGCB {
+  tkmc_list_head wait_queue;
+  ID flgid;
+  void *exinf;
+  ATR attr;
+  UINT flgptn;
+} FLGCB;
+
+extern void tkmc_init_flbcb(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/event_flag.h
+++ b/kernel/event_flag.h
@@ -19,7 +19,7 @@ typedef struct FLGCB {
   tkmc_list_head wait_queue;
   ID flgid;
   void *exinf;
-  ATR attr;
+  ATR flgatr;
   UINT flgptn;
 } FLGCB;
 

--- a/kernel/event_flag.h
+++ b/kernel/event_flag.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UUID_0195C76B_33EA_715C_A3A4_72FC38355057
+#define UUID_0195C76B_33EA_715C_A3A4_72FC38355057
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* UUID_0195C76B_33EA_715C_A3A4_72FC38355057 */

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -45,6 +45,13 @@ static inline void tkmc_list_del(tkmc_list_head *head) {
   head->next = head->prev = (tkmc_list_head *)0xdeadbeef;
 }
 
+static inline void tkmc_list_add(tkmc_list_head *new, tkmc_list_head *head) {
+  new->next = head->next;
+  new->prev = head;
+  head->next->prev = new;
+  head->next = new;
+}
+
 static inline void tkmc_list_add_tail(tkmc_list_head *new,
                                       tkmc_list_head *head) {
   new->next = head;

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -45,19 +45,22 @@ static inline void tkmc_list_del(tkmc_list_head *head) {
   head->next = head->prev = (tkmc_list_head *)0xdeadbeef;
 }
 
+static inline void tkmc_list_add_between(tkmc_list_head *new,
+                                         tkmc_list_head *prev,
+                                         tkmc_list_head *next) {
+  next->prev = new;
+  new->next = next;
+  new->prev = prev;
+  prev->next = new;
+}
+
 static inline void tkmc_list_add(tkmc_list_head *new, tkmc_list_head *head) {
-  new->next = head->next;
-  new->prev = head;
-  head->next->prev = new;
-  head->next = new;
+  tkmc_list_add_between(new, head, head->next);
 }
 
 static inline void tkmc_list_add_tail(tkmc_list_head *new,
                                       tkmc_list_head *head) {
-  new->next = head;
-  new->prev = head->prev;
-  new->prev->next = new;
-  head->prev = new;
+  tkmc_list_add_between(new, head->prev, head);
 }
 
 /* Macro to get the next element */

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -6,6 +6,7 @@
 
 #include <tk/tkernel.h>
 
+#include "event_flag.h"
 #include "ini_tsk.h"
 #include "task.h"
 #include "timer.h"
@@ -40,6 +41,7 @@ void tkmc_start(int a0, int a1) {
 
   /* Initialize the Task Control Block (TCB) system. */
   tkmc_init_tcb();
+  tkmc_init_flgcb();
   tkmc_init_timer();
 
   /* create tkmc_ini_tsk */

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -163,8 +163,8 @@ ID tk_cre_tsk(CONST T_CTSK *pk_ctsk) {
 
   if (new_id >= 0) {
     reset_tcb(new_tcb);
+
     /* Initialize the TCB for the new task */
-    new_tcb->tskstat = TTS_DMT; // Set initial task state
     static const UINT SZ = sizeof(StashedRegisters);
     stack_end -= SZ; // Reserve space for the initial context
     StashedRegisters *regs = (StashedRegisters *)stack_end;
@@ -173,10 +173,12 @@ ID tk_cre_tsk(CONST T_CTSK *pk_ctsk) {
     }
     regs->registers.ra = (UINT)tk_ext_tsk;      // Set return address (ra)
     regs->registers.mepc = (UINT)pk_ctsk->task; // Set task entry point (mepc)
-    new_tcb->sp = stack_end;                    // Set stack pointer
-    new_tcb->initial_sp = stack_end;            // Store initial stack pointer
-    new_tcb->task = pk_ctsk->task;              // Assign task function
-    new_tcb->itskpri = pk_ctsk->itskpri;        // Assign task priority
+
+    new_tcb->tskstat = TTS_DMT;          // Set initial task state
+    new_tcb->sp = stack_end;             // Set stack pointer
+    new_tcb->initial_sp = stack_end;     // Store initial stack pointer
+    new_tcb->task = pk_ctsk->task;       // Assign task function
+    new_tcb->itskpri = pk_ctsk->itskpri; // Assign task priority
     new_tcb->exinf = pk_ctsk->exinf; // Store user-defined extended information
   } else {
     new_id = (ID)E_LIMIT; // Task creation failed

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -15,6 +15,13 @@
 extern "C" {
 #endif /* __cplusplus */
 
+typedef struct WINFO {
+  tkmc_list_head wait_queue;
+  UINT waiptn;
+  UINT wfmode;
+  UINT flgptn;
+} WINFO;
+
 /* Task Control Block */
 typedef struct TCB {
   tkmc_list_head head;
@@ -29,6 +36,7 @@ typedef struct TCB {
   UINT delay_ticks;
   ER wupcause;
   UINT wupcnt;
+  WINFO winfo;
 } TCB;
 
 extern TCB *current;

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -15,42 +15,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-enum TaskState {
-  TTS_NOEXS = 0x0000,
-  TTS_RUN = 0x0001,
-  TTS_RDY = 0x0002,
-  TTS_WAI = 0x0004,
-  TTS_SUS = 0x0008,
-  TTS_WAS = 0x000c,
-  TTS_DMT = 0x0010,
-  TTS_NODISWAI = 0x0080,
-};
-
-enum TaskWait {
-  TTW_SLP = 0x00000001,  /**< Waiting due to `tk_slp_tsk` */
-  TTW_DLY = 0x00000002,  /**< Waiting due to `tk_dly_tsk` */
-  TTW_SEM = 0x00000004,  /**< Waiting due to `tk_wai_sem` */
-  TTW_FLG = 0x00000008,  /**< Waiting due to `tk_wai_flg` */
-  TTW_MBX = 0x00000040,  /**< Waiting due to `tk_rcv_mbx` */
-  TTW_MTX = 0x00000080,  /**< Waiting due to `tk_loc_mtx` */
-  TTW_SMBF = 0x00000100, /**< Waiting due to `tk_snd_mbf` */
-  TTW_RMBF = 0x00000200, /**< Waiting due to `tk_rcv_mbf` */
-  // TTW_CAL  = 0x00000400, /**< Reserved  */
-  // TTW_ACP  = 0x00000800, /**< Reserved  */
-  // TTW_RDV  = 0x00001000, /**< Reserved  */
-  // TTW_CAL_RDV = TTW_CAL|TTW_RDV, /**< Reserved */
-  TTW_MPF = 0x00002000, /**< Waiting due to `tk_get_mpf` */
-  TTW_MPL = 0x00004000, /**< Waiting due to `tk_get_mpl` */
-  TTW_EV1 = 0x00010000, /**< Waiting for Task Event #1 */
-  TTW_EV2 = 0x00020000, /**< Waiting for Task Event #2 */
-  TTW_EV3 = 0x00040000, /**< Waiting for Task Event #3 */
-  TTW_EV4 = 0x00080000, /**< Waiting for Task Event #4 */
-  TTW_EV5 = 0x00100000, /**< Waiting for Task Event #5 */
-  TTW_EV6 = 0x00200000, /**< Waiting for Task Event #6 */
-  TTW_EV7 = 0x00400000, /**< Waiting for Task Event #7 */
-  TTW_EV8 = 0x00800000  /**< Waiting for Task Event #8 */
-};
-
 /* Task Control Block */
 typedef struct TCB {
   tkmc_list_head head;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 // clang-format off
 #include <tk/tkernel.h>
 // clang-format on

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -84,7 +84,7 @@ void tkmc_timer_handler(void) {
  * - delay_ticks: Number of ticks to wait before the task is moved to the ready
  * queue.
  */
-void tkmc_schedule_timer(TCB *tcb, UINT delay_ticks, enum TaskWait tskwait) {
+void tkmc_schedule_timer(TCB *tcb, UINT delay_ticks, UINT tskwait) {
   tcb->tskstat = TTS_WAI;
   tcb->tskwait = tskwait;
   tcb->delay_ticks = delay_ticks;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -84,7 +84,7 @@ void tkmc_timer_handler(void) {
  * - delay_ticks: Number of ticks to wait before the task is moved to the ready
  * queue.
  */
-static void schedule_timer(TCB *tcb, UINT delay_ticks, enum TaskWait tskwait) {
+void tkmc_schedule_timer(TCB *tcb, UINT delay_ticks, enum TaskWait tskwait) {
   tcb->tskstat = TTS_WAI;
   tcb->tskwait = tskwait;
   tcb->delay_ticks = delay_ticks;
@@ -118,7 +118,7 @@ ER tk_dly_tsk(TMO dlytm) {
   /* Move the task to the timer queue with the specified timeout */
   UINT intsts;
   DI(intsts);
-  schedule_timer(current, ((dlytm + 9) / 10) + 1, TTW_DLY);
+  tkmc_schedule_timer(current, ((dlytm + 9) / 10) + 1, TTW_DLY);
   EI(intsts);
   // wait to be awaken
   DI(intsts);
@@ -146,7 +146,7 @@ ER tk_slp_tsk(TMO tmout) {
     return ercd;
   } else {
     if (tmout > 0) {
-      schedule_timer(current, ((tmout + 9) / 10) + 1, TTW_SLP);
+      tkmc_schedule_timer(current, ((tmout + 9) / 10) + 1, TTW_SLP);
     } else if (tmout == TMO_POL) {
       EI(intsts);
       return E_TMOUT;

--- a/kernel/timer.h
+++ b/kernel/timer.h
@@ -9,12 +9,16 @@
 
 #include <tk/tkernel.h>
 
+#include "task.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
 extern void tkmc_start_timer(void);
 extern void tkmc_init_timer(void);
+extern void tkmc_schedule_timer(TCB *tcb, UINT delay_ticks,
+                                enum TaskWait tskwait);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/timer.h
+++ b/kernel/timer.h
@@ -17,8 +17,7 @@ extern "C" {
 
 extern void tkmc_start_timer(void);
 extern void tkmc_init_timer(void);
-extern void tkmc_schedule_timer(TCB *tcb, UINT delay_ticks,
-                                enum TaskWait tskwait);
+extern void tkmc_schedule_timer(TCB *tcb, UINT delay_ticks, UINT tskwait);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/usermain.c
+++ b/kernel/usermain.c
@@ -8,19 +8,23 @@
 
 extern void task1(INT stacd, void *exinf);
 extern void task2(INT stacd, void *exinf);
+extern void task3(INT stacd, void *exinf);
 
 static UW task1_stack[256] __attribute__((aligned(16)));
 static UW task2_stack[256] __attribute__((aligned(16)));
-
-static ID s_id_map[2] = {
-    0,
-    0,
-};
+static UW task3_stack[256] __attribute__((aligned(16)));
 
 enum TASK_INDEX {
   TASK1 = 0,
-  TASK2 = 1,
+  TASK2,
+  TASK3,
   TASK_NBOF,
+};
+
+static ID s_id_map[TASK_NBOF] = {
+    0,
+    0,
+    0,
 };
 
 ID get_tskid(unsigned int index) {
@@ -35,30 +39,43 @@ static const char task2_exinf[] = "Task2";
 
 void usermain(int _a0) __attribute__((weak));
 void usermain(int _a0) {
-
-  T_CTSK pk_ctsk1 = {
-      .exinf = (void *)task1_exinf,
-      .tskatr = TA_USERBUF,
-      .task = (FP)task1,
-      .itskpri = 2,
-      .stksz = sizeof(task1_stack),
-      .bufptr = task1_stack,
-  };
-
-  T_CTSK pk_ctsk2 = {
-      .exinf = (void *)task2_exinf,
-      .tskatr = TA_USERBUF,
-      .task = (FP)task2,
-      .itskpri = 2,
-      .stksz = sizeof(task2_stack),
-      .bufptr = task2_stack,
-  };
-  ID task1_id = tk_cre_tsk(&pk_ctsk1);
-  ID task2_id = tk_cre_tsk(&pk_ctsk2);
-
-  s_id_map[TASK1] = task1_id;
-  s_id_map[TASK2] = task2_id;
-
-  tk_sta_tsk(task1_id, 0);
-  tk_sta_tsk(task2_id, 0);
+  {
+    T_CTSK pk_ctsk1 = {
+        .exinf = (void *)task1_exinf,
+        .tskatr = TA_USERBUF,
+        .task = (FP)task1,
+        .itskpri = 2,
+        .stksz = sizeof(task1_stack),
+        .bufptr = task1_stack,
+    };
+    ID task1_id = tk_cre_tsk(&pk_ctsk1);
+    s_id_map[TASK1] = task1_id;
+    tk_sta_tsk(task1_id, 0);
+  }
+  {
+    T_CTSK pk_ctsk2 = {
+        .exinf = (void *)task2_exinf,
+        .tskatr = TA_USERBUF,
+        .task = (FP)task2,
+        .itskpri = 2,
+        .stksz = sizeof(task2_stack),
+        .bufptr = task2_stack,
+    };
+    ID task2_id = tk_cre_tsk(&pk_ctsk2);
+    s_id_map[TASK2] = task2_id;
+    tk_sta_tsk(task2_id, 0);
+  }
+  {
+    T_CTSK pk_ctsk3 = {
+        .exinf = (void *)NULL,
+        .tskatr = TA_USERBUF,
+        .task = (FP)task3,
+        .itskpri = 3,
+        .stksz = sizeof(task3_stack),
+        .bufptr = task3_stack,
+    };
+    ID task3_id = tk_cre_tsk(&pk_ctsk3);
+    s_id_map[TASK3] = task3_id;
+    tk_sta_tsk(task3_id, 0);
+  }
 }

--- a/task1.c
+++ b/task1.c
@@ -8,9 +8,11 @@
 #include "putstring.h"
 
 extern ID get_tskid(unsigned int index);
+
 enum TASK_INDEX {
   TASK1 = 0,
-  TASK2 = 1,
+  TASK2,
+  TASK3,
   TASK_NBOF,
 };
 void task1(INT stacd, void *exinf) {

--- a/task2.c
+++ b/task2.c
@@ -8,9 +8,11 @@
 #include "putstring.h"
 
 extern ID get_tskid(unsigned int index);
+
 enum TASK_INDEX {
   TASK1 = 0,
-  TASK2 = 1,
+  TASK2,
+  TASK3,
   TASK_NBOF,
 };
 

--- a/task3.c
+++ b/task3.c
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <tk/tkernel.h>
+
+#include "putstring.h"
+
+extern ID get_tskid(unsigned int index);
+
+enum TASK_INDEX {
+  TASK1 = 0,
+  TASK2,
+  TASK3,
+  TASK_NBOF,
+};
+
+void task3(INT stacd, void *exinf) {
+  T_CFLG pk_cflg = {
+      .exinf = NULL,
+      .flgatr = TA_TFIFO | TA_WSGL,
+      .iflgptn = 0x00FFFFFF,
+
+  };
+  ID flgid = tk_cre_flg(&pk_cflg);
+  UINT flgptn = 0;
+  ER ercd;
+  ercd = tk_wai_flg(flgid, 0x00a5a5a5, TWF_ANDW | TWF_BITCLR, &flgptn, TMO_POL);
+  if (ercd == E_OK) {
+    putstring("TASK3: E_OK\n");
+  }
+  //
+  tk_ext_tsk();
+}

--- a/task3.c
+++ b/task3.c
@@ -59,6 +59,16 @@ void task3(INT stacd, void *exinf) {
     putstring("TASK3: E_TMOUT\n");
   }
 
+  ercd = tk_set_flg(flgid, 0x00000008);
+  if (ercd == E_OK) {
+    putstring("TASK3: E_OK\n");
+  }
+
+  ercd = tk_wai_flg(flgid, 0x00000008, TWF_ANDW | TWF_CLR, &flgptn, TMO_POL);
+  if (ercd == E_OK) { // expect true
+    putstring("TASK3: E_OK\n");
+  }
+
   // Exit task
   tk_ext_tsk();
 }

--- a/task3.c
+++ b/task3.c
@@ -9,27 +9,51 @@
 
 extern ID get_tskid(unsigned int index);
 
+/// Enum to identify each task by index
 enum TASK_INDEX {
   TASK1 = 0,
   TASK2,
   TASK3,
-  TASK_NBOF,
+  TASK_NBOF, // Number of tasks
 };
 
+/// Entry point for TASK3
+/// @param stacd Start code (startup information)
+/// @param exinf Extended information passed at task creation
 void task3(INT stacd, void *exinf) {
+  // Define flag creation parameters
   T_CFLG pk_cflg = {
-      .exinf = NULL,
-      .flgatr = TA_TFIFO | TA_WSGL,
-      .iflgptn = 0x00FFFFFF,
-
+      .exinf = NULL,                // No extended information
+      .flgatr = TA_TFIFO | TA_WSGL, // FIFO order, single wait allowed
+      .iflgptn = 0x00FFFFFF,        // Initial flag pattern (lower 24 bits set)
   };
+
+  // Create an event flag object
   ID flgid = tk_cre_flg(&pk_cflg);
   UINT flgptn = 0;
   ER ercd;
+
+  // Attempt to wait for all bits 0x00a5a5a5 to be set and then cleared
+  // (TWF_BITCLR) Expected: immediate success since all bits are initially set
   ercd = tk_wai_flg(flgid, 0x00a5a5a5, TWF_ANDW | TWF_BITCLR, &flgptn, TMO_POL);
-  if (ercd == E_OK) {
+  if (ercd == E_OK) { // expect true
     putstring("TASK3: E_OK\n");
   }
-  //
+
+  // Retry with same condition, expecting timeout because bits were cleared in
+  // previous wait
+  ercd = tk_wai_flg(flgid, 0x00a5a5a5, TWF_ANDW | TWF_BITCLR, &flgptn, TMO_POL);
+  if (ercd == E_TMOUT) { // expect true
+    putstring("TASK3: E_TMOUT\n");
+  }
+
+  // Try with OR condition for a slightly different pattern
+  // Expected: success, since lower bits still match at least part of 0x00a5a5a7
+  ercd = tk_wai_flg(flgid, 0x00a5a5a7, TWF_ORW | TWF_BITCLR, &flgptn, TMO_POL);
+  if (ercd == E_OK) { // expect true
+    putstring("TASK3: E_OK\n");
+  }
+
+  // Exit task
   tk_ext_tsk();
 }

--- a/task3.c
+++ b/task3.c
@@ -49,9 +49,14 @@ void task3(INT stacd, void *exinf) {
 
   // Try with OR condition for a slightly different pattern
   // Expected: success, since lower bits still match at least part of 0x00a5a5a7
-  ercd = tk_wai_flg(flgid, 0x00a5a5a7, TWF_ORW | TWF_BITCLR, &flgptn, TMO_POL);
+  ercd = tk_wai_flg(flgid, 0x00a5a5a7, TWF_ORW | TWF_CLR, &flgptn, TMO_POL);
   if (ercd == E_OK) { // expect true
     putstring("TASK3: E_OK\n");
+  }
+
+  ercd = tk_wai_flg(flgid, 0xFFFFFFFF, TWF_ORW, &flgptn, TMO_POL);
+  if (ercd == E_TMOUT) { // expect true
+    putstring("TASK3: E_TMOUT\n");
   }
 
   // Exit task

--- a/task3.c
+++ b/task3.c
@@ -69,6 +69,26 @@ void task3(INT stacd, void *exinf) {
     putstring("TASK3: E_OK\n");
   }
 
+  {
+    extern void task4(INT, void *);
+    static UW task4_stack[256] __attribute__((aligned(16)));
+    T_CTSK pk_ctsk4 = {
+        .exinf = NULL,
+        .tskatr = TA_USERBUF,
+        .task = (FP)task4,
+        .itskpri = 4,
+        .stksz = sizeof(task4_stack),
+        .bufptr = task4_stack,
+    };
+    ID task4_id = tk_cre_tsk(&pk_ctsk4);
+    tk_sta_tsk(task4_id, flgid);
+  }
+
+  ercd = tk_wai_flg(flgid, 0x00000008, TWF_ANDW | TWF_CLR, &flgptn, 1000);
+  if (ercd == E_OK) { // expect true
+    putstring("TASK3: E_OK. awaken by task\n");
+  }
+
   // Exit task
   tk_ext_tsk();
 }

--- a/task4.c
+++ b/task4.c
@@ -25,6 +25,11 @@ void task4(INT stacd, void *exinf) {
   ID flgid = (ID)stacd;
   UINT setptn = 0xFFFFFFFF;
 
+  UINT flgptn;
+  ER ercd = tk_wai_flg(flgid, 0xFFFFFFFF, TWF_ORW, &flgptn, TMO_FEVR);
+  if (ercd == E_OBJ) {
+    putstring("TASK4: E_OBJ\n");
+  }
   tk_set_flg(flgid, setptn);
 
   // Exit task

--- a/task4.c
+++ b/task4.c
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Daisuke Nagao
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <tk/tkernel.h>
+
+#include "putstring.h"
+
+extern ID get_tskid(unsigned int index);
+
+/// Enum to identify each task by index
+enum TASK_INDEX {
+  TASK1 = 0,
+  TASK2,
+  TASK3,
+  TASK4,
+  TASK_NBOF, // Number of tasks
+};
+
+/// Entry point for TASK4
+/// @param stacd Start code (startup information)
+/// @param exinf Extended information passed at task creation
+void task4(INT stacd, void *exinf) {
+  ID flgid = (ID)stacd;
+  UINT setptn = 0xFFFFFFFF;
+
+  tk_set_flg(flgid, setptn);
+
+  // Exit task
+  tk_ext_tsk();
+}

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -31,7 +31,7 @@ set(CMAKE_ASM_FLAGS_INIT "${RISCV_COMPILE_OPTIONS}")
 
 # Set linker flags
 set(CMAKE_EXE_LINKER_FLAGS_INIT
-    "-nostdlib -nostartfiles -T ${CMAKE_SOURCE_DIR}/linker.ld")
+    "-nostdlib -nostartfiles -T \"${CMAKE_SOURCE_DIR}/linker.ld\"")
 
 # Set include and library paths (adjust as needed)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION

## Description

This commit introduces a fully functional **event flag mechanism** compliant with μT-Kernel specifications and adds new test tasks (`task3`, `task4`) to verify its correctness under various flag operations.

### Key Changes:

- **Implement core event flag kernel module**
  - Add `event_flag.c`, `event_flag.h` with support for:
    - `tk_cre_flg()`, `tk_set_flg()`, `tk_clr_flg()`, `tk_wai_flg()`
    - Wait modes: `TWF_ANDW`, `TWF_ORW`, `TWF_CLR`, `TWF_BITCLR`
    - Wait queue handling: `TA_TFIFO`, `TA_TPRI`, `TA_WSGL`, `TA_WMUL`

- **Extend internal kernel state**
  - Add `WINFO` structure to `TCB` for flag wait context
  - Track `tskstat`, `tskwait`, and extended result codes (`wupcause`)

- **Refactor `timer.c`**
  - Introduce `tkmc_schedule_timer()` for consistent delayed wait setup

- **Enhance stack frame handling**
  - Define `StashedRegisters` to standardise trap context
  - Align `tk_cre_tsk()` to use this layout on stack

- **Integrate new test tasks**
  - `task3`:
    - Tests flag creation, condition matching, clearing behaviour
    - Spawns `task4` to trigger condition via `tk_set_flg()`
  - `task4`:
    - Waits on `tk_wai_flg`, then sets the expected bit to wake `task3`

- **Update `usermain` and build configuration**
  - Launch all tasks including new `task3`, `task4`
  - Add `task3.c`, `task4.c` to `tkmc_add_executable()` call
  - Enable `CFN_MAX_FLGID` in `sys/config.h`

## Rationale

This change completes core support for **synchronisation via event flags**, a crucial RTOS primitive. The addition of `task3` and `task4` provides a regression-testable scenario to ensure:
- Immediate success or timeout is correctly handled
- Bitwise wait conditions (`ANDW`, `ORW`) behave as expected
- Flag clearing logic (all or bitwise) functions properly
- Single-wait and multi-wait flags are enforced correctly

This paves the way for implementing semaphores, message boxes, and more complex IPC primitives.