### PR TITLE
Add 64-bit I/O Port Access Functions and Enable I/O Port Support

### DIFF
--- a/include/sys/ioport.h
+++ b/include/sys/ioport.h
@@ -16,10 +16,21 @@ extern "C" {
 static inline void out_b(INT port, UB data) { *(_UB *)port = data; }
 static inline void out_h(INT port, UH data) { *(_UH *)port = data; }
 static inline void out_w(INT port, UW data) { *(_UW *)port = data; }
+static inline void out_d(INT port, UD data) {
+  // Write lower 32 bits first
+  out_w(port, (UW)(data & 0xFFFFFFFFUL));
+  // Then write upper 32 bits to next 4 bytes (offset +4)
+  out_w(port + 4, (UW)(data >> 32));
+}
 
 static inline UB in_b(INT port) { return *(_UB *)port; }
 static inline UH in_h(INT port) { return *(_UH *)port; }
 static inline UW in_w(INT port) { return *(_UW *)port; }
+static inline UD in_d(INT port) {
+  UD low = (UD)in_w(port);
+  UD high = (UD)in_w(port + 4);
+  return low | (high << 32);
+}
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/sys/profile.h
+++ b/include/sys/profile.h
@@ -10,7 +10,7 @@
 /* Device Driver Functions */
 #define TK_SUPPORT_TASKEVENT FALSE /* Support of task event */
 #define TK_SUPPORT_DISWAI FALSE    /* Support of disabling wait */
-#define TK_SUPPORT_IOPORT FALSE    /* Support of I/O port access */
+#define TK_SUPPORT_IOPORT TRUE     /* Support of I/O port access */
 #define TK_SUPPORT_MICROWAIT FALSE /* Support of micro wait */
 
 /* Power Management Functions */


### PR DESCRIPTION
## Description

This commit enhances the I/O port access header to support 64-bit operations and enables I/O port access support in the kernel configuration.

### Key Changes:

- **Add 64-bit I/O port access functions**
  - `out_d(INT port, UD data)`:
    - Writes a 64-bit value by splitting into two 32-bit writes.
    - Lower 32 bits are written first to `port`, upper 32 bits to `port + 4`.
  - `in_d(INT port)`:
    - Reads two 32-bit values from `port` and `port + 4` and combines them into a `UD`.

- **Enable I/O port support in `profile.h`**
  - Set `TK_SUPPORT_IOPORT` to `TRUE`.

## Rationale

Some architectures and devices require 64-bit I/O access (e.g. timers, memory-mapped peripherals).  
This patch enables proper support while preserving compatibility with 8/16/32-bit access. It also activates feature gating to allow future driver code to conditionally use I/O port access.