### PR TITLE
Add `tk_exd_tsk()` for Task Termination and Deletion

### DIFF
--- a/include/tk/tkernel.h
+++ b/include/tk/tkernel.h
@@ -93,6 +93,7 @@ typedef struct T_CTSK {
 } T_CTSK;
 
 extern void tk_ext_tsk(void);
+extern void tk_exd_tsk(void);
 extern ID tk_cre_tsk(CONST T_CTSK *pk_ctsk);
 extern ER tk_sta_tsk(ID tskid, INT stacd);
 extern ER tk_dly_tsk(TMO dlytm);

--- a/kernel/ini_tsk.c
+++ b/kernel/ini_tsk.c
@@ -10,5 +10,5 @@ extern void usermain(int _a0);
 
 void tkmc_ini_tsk(INT stacd, void *exinf) {
   usermain(stacd);
-  tk_ext_tsk();
+  tk_exd_tsk();
 }


### PR DESCRIPTION

## Description

This commit introduces `tk_exd_tsk()`, a new system call that terminates the **current task** and **returns it to the free list**, making it reusable for future task creation.

### Key Changes:

- **Add `tk_exd_tsk()` function**
  - Sets the current task's state to `TTS_NOEXS`.
  - Returns the `TCB` to `tkmc_free_tcb` list.
  - Triggers context switch.
  - Does **not** return (like `tk_ext_tsk()`).

- **Update `tk_ext_tsk()`**
  - Clarified as only terminating the task (transition to `TTS_DMT`), not deleting it.
  - Expanded comments for maintainability.

- **Update `tkmc_ini_tsk()`**
  - Replace `tk_ext_tsk()` with `tk_exd_tsk()` to cleanly terminate and recycle the initial task.

- **Add prototype to `tkernel.h`**
  - Added `extern void tk_exd_tsk(void);`.

## Rationale

- Separating termination (`tk_ext_tsk`) and termination+deletion (`tk_exd_tsk`) aligns with uT-Kernel 3.0 semantics.
- Frees up `TCB` slots for dynamic or loop-based task creation scenarios.
- Prevents memory/resource leaks when temporary tasks are used.