### PR TITLE
[Fix] Correct return value of schedule to restore task context properly

### DIFF
--- a/kernel/asm/rv32/start.S
+++ b/kernel/asm/rv32/start.S
@@ -69,7 +69,7 @@ mtrap_handler:
 
   mv a0, sp
   call schedule
-  lw sp, 0(a0)
+  mv sp, a0
 
   lw a0, 28*4(sp)
   csrw mepc, a0

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -138,5 +138,5 @@ void **schedule(void *sp) {
   current = next;
 
   /* Return the stack pointer of the next task. */
-  return &current->sp;
+  return current->sp;
 }


### PR DESCRIPTION
- Changed `schedule` to return `current->sp` instead of `&current->sp`
- Updated `start.S` to restore `sp` using `mv sp, a0` instead of `lw sp, 0(a0)`
- Fixes incorrect stack pointer restoration during context switch